### PR TITLE
feat: Enhance REST API tools with AsyncApexJob search and retrieval m…

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,14 @@ your_private_key_content
 
 ### Available Tools
 
+#### REST API Tools
+- `search_async_apex_jobs` - Search AsyncApexJob records with filtering by status, job type, Apex class name, date range
+- `get_async_apex_job` - Get detailed information about a specific AsyncApexJob by ID
+- `call_rest_api` - Make generic REST API calls to Salesforce
+- `get_org_limits` - Get organization limits information
+- `get_sobjects_list` - Get list of all available SObjects
+- `describe_sobject` - Describe a specific SObject schema
+
 #### Apex Class Management
 - `list_apex_classes` - List all Apex classes with optional filtering
 - `get_apex_class` - Get detailed information about a specific Apex class
@@ -216,6 +224,9 @@ your_private_key_content
 
 Once the MCP server is running and connected to Claude, you can use natural language commands like:
 
+- "Search for completed AsyncApexJob records for BatchProcessor class"
+- "Get details of AsyncApexJob with ID 707XXXXXXXXXXXXXXX"
+- "Find all failed batch jobs from the last week"
 - "List all Apex classes that contain 'Account' in their name"
 - "Show me the code coverage for all classes below 75%"
 - "Get the symbol table for the AccountTriggerHandler class"


### PR DESCRIPTION
This pull request adds new REST API tools for working with Salesforce AsyncApexJob records, updates the documentation to reflect these new capabilities, and enhances the `SalesforceRestClient` to intelligently route Tooling API queries. The changes improve both the developer experience and the available automation around Apex job management.

**New AsyncApexJob Tools and API Enhancements:**

* Added two new REST API tools: `search_async_apex_jobs` for searching jobs with flexible filters, and `get_async_apex_job` for fetching details of a specific job by ID. These tools use the Tooling API under the hood and include robust input validation and error handling.
* Updated the `SalesforceRestClient` to:
  - Route SOQL queries containing Tooling API objects (like `AsyncApexJob` and `ApexClass`) to the Tooling API automatically.
  - Provide new methods: `getAsyncApexJobs`, `getAsyncApexJob`, and `searchAsyncApexJobs` for programmatic access to AsyncApexJob data.
  - Internally instantiate and use a `SalesforceToolingClient` for these operations.

**Documentation Updates:**

* Expanded the `README.md` to document the new REST API tools and provide example natural language queries for working with AsyncApexJob records. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R173-R180) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R227-R229)