### PR TITLE
Add unit tests for SalesforceRestClient and SalesforceToolingClient

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,21 @@
+module.exports = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  testMatch: ['**/__tests__/**/*.test.ts'],
+  transform: {
+    '^.+\\.ts$': ['ts-jest', {
+      useESM: true,
+    }],
+  },
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!src/**/*.d.ts',
+    '!src/index.ts',
+  ],
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,12 +18,14 @@
         "salesforce-mcp-server": "build/index.js"
       },
       "devDependencies": {
+        "@types/jest": "^30.0.0",
         "@types/node": "^20.11.24",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
         "eslint": "^8.56.0",
         "jest": "^29.7.0",
         "prettier": "^3.2.5",
+        "ts-jest": "^29.4.1",
         "tsx": "^4.7.1",
         "typescript": "^5.3.3"
       },
@@ -1335,6 +1337,16 @@
         }
       }
     },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
+      "integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/environment": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
@@ -1396,6 +1408,16 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/get-type": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.0.1.tgz",
+      "integrity": "sha512-AyYdemXCptSRFirI5EPazNxyPwAL0jXt3zceFjaj8NFiKP9pOi0bfXonf6qkf82z2t3QWPeLCWWw4stPBzctLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/globals": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
@@ -1410,6 +1432,30 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+      "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern/node_modules/jest-regex-util": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/reporters": {
@@ -1756,6 +1802,230 @@
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/expect-utils": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.0.5.tgz",
+      "integrity": "sha512-F3lmTT7CXWYywoVUGTCmom0vXq3HTTkaZyTAzIy+bXSBizB7o5qzlC9VCtq0arOa8GqmNsbg/cE9C6HLn7Szew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/types": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.0.5.tgz",
+      "integrity": "sha512-aREYa3aku9SSnea4aX6bhKn4bgv3AXkgijoQgbYV3yvbiGt6z+MQ85+6mIhx9DsKW2BuB/cLR/A+tcMThx+KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@sinclair/typebox": {
+      "version": "0.34.40",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.40.tgz",
+      "integrity": "sha512-gwBNIP8ZAYev/ORDWW0QvxdwPXwxBtLsdsJgSc7eDIRt8ubP+rxUBzPsrwnu16fgEF8Bx4lh/+mvQvJzcTM6Kw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jest/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/ci-info": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.0.tgz",
+      "integrity": "sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@types/jest/node_modules/expect": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.0.5.tgz",
+      "integrity": "sha512-P0te2pt+hHI5qLJkIR+iMvS+lYUZml8rKKsohVHAGY+uClp9XVbdyYNJOIjSRpHVp8s8YqxJCiHUkSYZGr8rtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "30.0.5",
+        "@jest/get-type": "30.0.1",
+        "jest-matcher-utils": "30.0.5",
+        "jest-message-util": "30.0.5",
+        "jest-mock": "30.0.5",
+        "jest-util": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-diff": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.0.5.tgz",
+      "integrity": "sha512-1UIqE9PoEKaHcIKvq2vbibrCog4Y8G0zmOxgQUVEiTqwR5hJVMCoDsN1vFvI5JvwD37hjueZ1C4l2FyGnfpE0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.0.1",
+        "@jest/get-type": "30.0.1",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-matcher-utils": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.0.5.tgz",
+      "integrity": "sha512-uQgGWt7GOrRLP1P7IwNWwK1WAQbq+m//ZY0yXygyfWp0rJlksMSLQAA4wYQC3b6wl3zfnchyTx+k3HZ5aPtCbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.0.1",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.0.5",
+        "pretty-format": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-message-util": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.0.5.tgz",
+      "integrity": "sha512-NAiDOhsK3V7RU0Aa/HnrQo+E4JlbarbmI3q6Pi4KcxicdtjV82gcIUrejOtczChtVQR4kddu1E1EJlW6EN9IyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.0.5",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "micromatch": "^4.0.8",
+        "pretty-format": "30.0.5",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-mock": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.0.5.tgz",
+      "integrity": "sha512-Od7TyasAAQX/6S+QCbN6vZoWOMwlTtzzGuxJku1GhGanAjz9y+QsQkpScDmETvdc9aSXyJ/Op4rhpMYBWW91wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.0.5",
+        "@types/node": "*",
+        "jest-util": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-util": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.0.5.tgz",
+      "integrity": "sha512-pvyPWssDZR0FlfMxCBoc0tvM8iUEskaRFALUtGQYzVEAqisAztmy+R8LnU14KT4XA0H/a5HMVTXat1jLne010g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.0.5",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@types/jest/node_modules/pretty-format": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.5.tgz",
+      "integrity": "sha512-D1tKtYvByrBkFLe2wHJl2bwMJIiT8rW+XA+TiataH79/FszLQMrpGEvzUVkzPau7OCO0Qnrhpe87PqtOAIB8Yw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@types/json-schema": {
@@ -2341,6 +2611,19 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/bser": {
@@ -3542,6 +3825,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -4612,6 +4917,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -4644,6 +4956,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -4742,6 +5061,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -4753,6 +5082,13 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5658,6 +5994,72 @@
         "typescript": ">=4.2.0"
       }
     },
+    "node_modules/ts-jest": {
+      "version": "29.4.1",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.1.tgz",
+      "integrity": "sha512-SaeUtjfpg9Uqu8IbeDKtdaS0g8lS6FT6OzM3ezrDfErPJPHNDo/Ey+VFGP1bQIDfagYDLyRpd7O15XpG1Es2Uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "fast-json-stable-stringify": "^2.1.0",
+        "handlebars": "^4.7.8",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.7.2",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <6"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tsx": {
       "version": "4.20.3",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.3.tgz",
@@ -5726,6 +6128,20 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/undici-types": {
@@ -5835,6 +6251,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -35,12 +35,14 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@types/jest": "^30.0.0",
     "@types/node": "^20.11.24",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
     "eslint": "^8.56.0",
     "jest": "^29.7.0",
     "prettier": "^3.2.5",
+    "ts-jest": "^29.4.1",
     "tsx": "^4.7.1",
     "typescript": "^5.3.3"
   },

--- a/src/client/__tests__/rest-client.test.ts
+++ b/src/client/__tests__/rest-client.test.ts
@@ -1,0 +1,431 @@
+import axios from 'axios';
+import { SalesforceRestClient } from '../rest-client';
+import { SalesforceAuth } from '../../auth/salesforce-auth';
+import { SalesforceToolingClient } from '../tooling-client';
+import { SalesforceConfig } from '../../types/index';
+
+jest.mock('axios');
+jest.mock('../../auth/salesforce-auth');
+jest.mock('../tooling-client');
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+const MockedSalesforceAuth = SalesforceAuth as jest.MockedClass<typeof SalesforceAuth>;
+const MockedSalesforceToolingClient = SalesforceToolingClient as jest.MockedClass<typeof SalesforceToolingClient>;
+
+describe('SalesforceRestClient', () => {
+  let client: SalesforceRestClient;
+  let mockHttpClient: any;
+  let mockAuth: jest.Mocked<SalesforceAuth>;
+  let mockToolingClient: jest.Mocked<SalesforceToolingClient>;
+  let config: SalesforceConfig;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    config = {
+      instanceUrl: 'https://test.salesforce.com',
+      clientId: 'test-client-id',
+      username: 'test@example.com',
+      password: 'testpass',
+      apiVersion: '59.0'
+    };
+
+    mockHttpClient = jest.fn().mockImplementation(() => Promise.resolve({ data: {} }));
+    Object.assign(mockHttpClient, {
+      get: jest.fn(),
+      post: jest.fn(),
+      patch: jest.fn(),
+      delete: jest.fn(),
+      interceptors: {
+        request: { use: jest.fn() },
+        response: { use: jest.fn() }
+      }
+    });
+
+    mockAuth = {
+      getAccessToken: jest.fn().mockResolvedValue('fake-token'),
+      getInstanceUrl: jest.fn().mockReturnValue('https://test.salesforce.com')
+    } as any;
+
+    mockToolingClient = {
+      query: jest.fn()
+    } as any;
+
+    MockedSalesforceAuth.mockImplementation(() => mockAuth);
+    MockedSalesforceToolingClient.mockImplementation(() => mockToolingClient);
+    mockedAxios.create.mockReturnValue(mockHttpClient);
+
+    client = new SalesforceRestClient(config);
+  });
+
+  describe('constructor', () => {
+    it('should create a SalesforceRestClient instance', () => {
+      expect(client).toBeInstanceOf(SalesforceRestClient);
+      expect(MockedSalesforceAuth).toHaveBeenCalledWith(config);
+      expect(MockedSalesforceToolingClient).toHaveBeenCalledWith(config);
+      expect(mockedAxios.create).toHaveBeenCalledWith({
+        timeout: 30000,
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+      });
+    });
+
+    it('should setup interceptors', () => {
+      expect(mockHttpClient.interceptors.request.use).toHaveBeenCalled();
+      expect(mockHttpClient.interceptors.response.use).toHaveBeenCalled();
+    });
+  });
+
+  describe('callApi', () => {
+    it('should make GET request', async () => {
+      const mockResponse = { data: { success: true } };
+      mockHttpClient.mockResolvedValue(mockResponse);
+
+      const result = await client.callApi('sobjects');
+
+      expect(mockHttpClient).toHaveBeenCalledWith({
+        method: 'GET',
+        url: 'sobjects',
+        params: undefined
+      });
+      expect(result).toEqual(mockResponse.data);
+    });
+
+    it('should make POST request with body', async () => {
+      const mockResponse = { data: { id: '123', success: true } };
+      const requestBody = { Name: 'Test Account' };
+      
+      mockHttpClient.mockResolvedValue(mockResponse);
+
+      const result = await client.callApi('sobjects/Account', 'POST', requestBody);
+
+      expect(mockHttpClient).toHaveBeenCalledWith({
+        method: 'POST',
+        url: 'sobjects/Account',
+        params: undefined,
+        data: requestBody
+      });
+      expect(result).toEqual(mockResponse.data);
+    });
+
+    it('should make PATCH request with body', async () => {
+      const mockResponse = { data: {} };
+      const requestBody = { Name: 'Updated Account' };
+      
+      mockHttpClient.mockResolvedValue(mockResponse);
+
+      const result = await client.callApi('sobjects/Account/123', 'PATCH', requestBody);
+
+      expect(mockHttpClient).toHaveBeenCalledWith({
+        method: 'PATCH',
+        url: 'sobjects/Account/123',
+        params: undefined,
+        data: requestBody
+      });
+      expect(result).toEqual(mockResponse.data);
+    });
+
+    it('should make DELETE request', async () => {
+      const mockResponse = { data: {} };
+      
+      mockHttpClient.mockResolvedValue(mockResponse);
+
+      const result = await client.callApi('sobjects/Account/123', 'DELETE');
+
+      expect(mockHttpClient).toHaveBeenCalledWith({
+        method: 'DELETE',
+        url: 'sobjects/Account/123',
+        params: undefined
+      });
+      expect(result).toEqual(mockResponse.data);
+    });
+
+    it('should include query parameters', async () => {
+      const mockResponse = { data: { records: [] } };
+      const params = { q: 'SELECT Id FROM Account' };
+      
+      mockHttpClient.mockResolvedValue(mockResponse);
+
+      const result = await client.callApi('query', 'GET', null, params);
+
+      expect(mockHttpClient).toHaveBeenCalledWith({
+        method: 'GET',
+        url: 'query',
+        params: params
+      });
+      expect(result).toEqual(mockResponse.data);
+    });
+  });
+
+  describe('getLimits', () => {
+    it('should get organization limits', async () => {
+      const mockResponse = { data: { DailyApiRequests: { Remaining: 100000, Max: 100000 } } };
+      mockHttpClient.mockResolvedValue(mockResponse);
+
+      const result = await client.getLimits();
+
+      expect(mockHttpClient).toHaveBeenCalledWith({
+        method: 'GET',
+        url: 'limits',
+        params: undefined
+      });
+      expect(result).toEqual(mockResponse.data);
+    });
+  });
+
+  describe('getSObjects', () => {
+    it('should get all sobjects', async () => {
+      const mockResponse = { data: { sobjects: [{ name: 'Account' }, { name: 'Contact' }] } };
+      mockHttpClient.mockResolvedValue(mockResponse);
+
+      const result = await client.getSObjects();
+
+      expect(mockHttpClient).toHaveBeenCalledWith({
+        method: 'GET',
+        url: 'sobjects',
+        params: undefined
+      });
+      expect(result).toEqual(mockResponse.data);
+    });
+  });
+
+  describe('describeSObject', () => {
+    it('should describe sobject', async () => {
+      const mockResponse = { data: { name: 'Account', fields: [] } };
+      mockHttpClient.mockResolvedValue(mockResponse);
+
+      const result = await client.describeSObject('Account');
+
+      expect(mockHttpClient).toHaveBeenCalledWith({
+        method: 'GET',
+        url: 'sobjects/Account/describe',
+        params: undefined
+      });
+      expect(result).toEqual(mockResponse.data);
+    });
+  });
+
+  describe('query', () => {
+    it('should route tooling API queries to tooling client', async () => {
+      const mockResponse = { totalSize: 1, done: true, records: [{ Id: '123' }] };
+      mockToolingClient.query.mockResolvedValue(mockResponse);
+
+      const result = await client.query('SELECT Id FROM ApexClass');
+
+      expect(mockToolingClient.query).toHaveBeenCalledWith('SELECT Id FROM ApexClass');
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should route standard queries to REST API', async () => {
+      const mockResponse = { data: { totalSize: 1, done: true, records: [{ Id: '123' }] } };
+      mockHttpClient.mockResolvedValue(mockResponse);
+
+      const result = await client.query('SELECT Id FROM Account');
+
+      expect(mockHttpClient).toHaveBeenCalledWith({
+        method: 'GET',
+        url: 'query',
+        params: { q: 'SELECT Id FROM Account' }
+      });
+      expect(result).toEqual(mockResponse.data);
+    });
+
+    it('should detect AsyncApexJob as tooling object', async () => {
+      const mockResponse = { totalSize: 1, done: true, records: [{ Id: '123' }] };
+      mockToolingClient.query.mockResolvedValue(mockResponse);
+
+      const result = await client.query('SELECT Id FROM AsyncApexJob');
+
+      expect(mockToolingClient.query).toHaveBeenCalledWith('SELECT Id FROM AsyncApexJob');
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('queryMore', () => {
+    it('should execute queryMore', async () => {
+      const mockResponse = { data: { totalSize: 1, done: true, records: [{ Id: '456' }] } };
+      mockHttpClient.get.mockResolvedValue(mockResponse);
+
+      const result = await client.queryMore('/services/data/v59.0/query/123-abc');
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith('/services/data/v59.0/query/123-abc');
+      expect(result).toEqual(mockResponse.data);
+    });
+  });
+
+  describe('createRecord', () => {
+    it('should create a record', async () => {
+      const mockResponse = { data: { id: '123', success: true } };
+      const recordData = { Name: 'Test Account' };
+      
+      mockHttpClient.mockResolvedValue(mockResponse);
+
+      const result = await client.createRecord('Account', recordData);
+
+      expect(mockHttpClient).toHaveBeenCalledWith({
+        method: 'POST',
+        url: 'sobjects/Account',
+        params: undefined,
+        data: recordData
+      });
+      expect(result).toEqual(mockResponse.data);
+    });
+  });
+
+  describe('getRecord', () => {
+    it('should get a record by id', async () => {
+      const mockResponse = { data: { Id: '123', Name: 'Test Account' } };
+      mockHttpClient.mockResolvedValue(mockResponse);
+
+      const result = await client.getRecord('Account', '123');
+
+      expect(mockHttpClient).toHaveBeenCalledWith({
+        method: 'GET',
+        url: 'sobjects/Account/123',
+        params: {}
+      });
+      expect(result).toEqual(mockResponse.data);
+    });
+
+    it('should get a record with specific fields', async () => {
+      const mockResponse = { data: { Id: '123', Name: 'Test Account' } };
+      mockHttpClient.mockResolvedValue(mockResponse);
+
+      const result = await client.getRecord('Account', '123', ['Id', 'Name']);
+
+      expect(mockHttpClient).toHaveBeenCalledWith({
+        method: 'GET',
+        url: 'sobjects/Account/123',
+        params: { fields: 'Id,Name' }
+      });
+      expect(result).toEqual(mockResponse.data);
+    });
+  });
+
+  describe('updateRecord', () => {
+    it('should update a record', async () => {
+      const mockResponse = { data: {} };
+      const updateData = { Name: 'Updated Account' };
+      
+      mockHttpClient.mockResolvedValue(mockResponse);
+
+      await client.updateRecord('Account', '123', updateData);
+
+      expect(mockHttpClient).toHaveBeenCalledWith({
+        method: 'PATCH',
+        url: 'sobjects/Account/123',
+        params: undefined,
+        data: updateData
+      });
+    });
+  });
+
+  describe('deleteRecord', () => {
+    it('should delete a record', async () => {
+      const mockResponse = { data: {} };
+      mockHttpClient.mockResolvedValue(mockResponse);
+
+      await client.deleteRecord('Account', '123');
+
+      expect(mockHttpClient).toHaveBeenCalledWith({
+        method: 'DELETE',
+        url: 'sobjects/Account/123',
+        params: undefined
+      });
+    });
+  });
+
+  describe('getAsyncApexJobs', () => {
+    it('should get all async apex jobs', async () => {
+      const mockResponse = { totalSize: 1, done: true, records: [{ Id: 'job123' }] };
+      mockToolingClient.query.mockResolvedValue(mockResponse);
+
+      const result = await client.getAsyncApexJobs();
+
+      expect(mockToolingClient.query).toHaveBeenCalledWith(
+        'SELECT Id, Status, JobType, MethodName, JobItemsProcessed, TotalJobItems, NumberOfErrors, CompletedDate, CreatedDate, CreatedBy.Name FROM AsyncApexJob ORDER BY CreatedDate DESC LIMIT 100'
+      );
+      expect(result).toEqual(mockResponse.records);
+    });
+
+    it('should get async apex jobs with status filter', async () => {
+      const mockResponse = { totalSize: 1, done: true, records: [{ Id: 'job123' }] };
+      mockToolingClient.query.mockResolvedValue(mockResponse);
+
+      const result = await client.getAsyncApexJobs('Completed', 50);
+
+      expect(mockToolingClient.query).toHaveBeenCalledWith(
+        "SELECT Id, Status, JobType, MethodName, JobItemsProcessed, TotalJobItems, NumberOfErrors, CompletedDate, CreatedDate, CreatedBy.Name FROM AsyncApexJob WHERE Status = 'Completed' ORDER BY CreatedDate DESC LIMIT 50"
+      );
+      expect(result).toEqual(mockResponse.records);
+    });
+  });
+
+  describe('getAsyncApexJob', () => {
+    it('should get a specific async apex job', async () => {
+      const mockResponse = { totalSize: 1, done: true, records: [{ Id: 'job123', Status: 'Completed' }] };
+      mockToolingClient.query.mockResolvedValue(mockResponse);
+
+      const result = await client.getAsyncApexJob('job123');
+
+      expect(mockToolingClient.query).toHaveBeenCalledWith(
+        "SELECT Id, Status, JobType, MethodName, JobItemsProcessed, TotalJobItems, NumberOfErrors, CompletedDate, CreatedDate, CreatedBy.Name, ExtendedStatus FROM AsyncApexJob WHERE Id = 'job123'"
+      );
+      expect(result).toEqual(mockResponse.records[0]);
+    });
+  });
+
+  describe('searchAsyncApexJobs', () => {
+    it('should search async apex jobs with all filters', async () => {
+      const mockResponse = { totalSize: 1, done: true, records: [{ Id: 'job123' }] };
+      mockToolingClient.query.mockResolvedValue(mockResponse);
+
+      const searchParams = {
+        status: 'Completed',
+        jobType: 'BatchApex',
+        apexClassName: 'TestBatch',
+        createdDateFrom: '2023-01-01T00:00:00Z',
+        createdDateTo: '2023-12-31T23:59:59Z',
+        limit: 50
+      };
+
+      const result = await client.searchAsyncApexJobs(searchParams);
+
+      expect(mockToolingClient.query).toHaveBeenCalledWith(
+        "SELECT Id, Status, JobType, MethodName, JobItemsProcessed, TotalJobItems, NumberOfErrors, CompletedDate, CreatedDate, CreatedBy.Name, ApexClass.Name FROM AsyncApexJob WHERE 1=1 AND Status = 'Completed' AND JobType = 'BatchApex' AND ApexClass.Name LIKE '%TestBatch%' AND CreatedDate >= 2023-01-01T00:00:00Z AND CreatedDate <= 2023-12-31T23:59:59Z ORDER BY CreatedDate DESC LIMIT 50"
+      );
+      expect(result).toEqual(mockResponse.records);
+    });
+
+    it('should search async apex jobs without filters', async () => {
+      const mockResponse = { totalSize: 1, done: true, records: [{ Id: 'job123' }] };
+      mockToolingClient.query.mockResolvedValue(mockResponse);
+
+      const result = await client.searchAsyncApexJobs({});
+
+      expect(mockToolingClient.query).toHaveBeenCalledWith(
+        'SELECT Id, Status, JobType, MethodName, JobItemsProcessed, TotalJobItems, NumberOfErrors, CompletedDate, CreatedDate, CreatedBy.Name, ApexClass.Name FROM AsyncApexJob WHERE 1=1 ORDER BY CreatedDate DESC LIMIT 100'
+      );
+      expect(result).toEqual(mockResponse.records);
+    });
+  });
+
+  describe('getAuth', () => {
+    it('should get authentication info', async () => {
+      mockAuth.getAccessToken.mockResolvedValue('test-token');
+      mockAuth.getInstanceUrl.mockReturnValue('https://test.salesforce.com');
+
+      const result = await client.getAuth();
+
+      expect(mockAuth.getAccessToken).toHaveBeenCalled();
+      expect(mockAuth.getInstanceUrl).toHaveBeenCalled();
+      expect(result).toEqual({
+        token: 'test-token',
+        instanceUrl: 'https://test.salesforce.com',
+        apiVersion: '59.0'
+      });
+    });
+  });
+});

--- a/src/client/__tests__/tooling-client.test.ts
+++ b/src/client/__tests__/tooling-client.test.ts
@@ -1,0 +1,456 @@
+import axios from 'axios';
+import { SalesforceToolingClient } from '../tooling-client';
+import { SalesforceAuth } from '../../auth/salesforce-auth';
+import { SalesforceConfig } from '../../types/index';
+
+jest.mock('axios');
+jest.mock('../../auth/salesforce-auth');
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+const MockedSalesforceAuth = SalesforceAuth as jest.MockedClass<typeof SalesforceAuth>;
+
+describe('SalesforceToolingClient', () => {
+  let client: SalesforceToolingClient;
+  let mockHttpClient: any;
+  let mockAuth: jest.Mocked<SalesforceAuth>;
+  let config: SalesforceConfig;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    config = {
+      instanceUrl: 'https://test.salesforce.com',
+      clientId: 'test-client-id',
+      username: 'test@example.com',
+      password: 'testpass',
+      apiVersion: '59.0'
+    };
+
+    mockHttpClient = {
+      get: jest.fn(),
+      post: jest.fn(),
+      patch: jest.fn(),
+      delete: jest.fn(),
+      interceptors: {
+        request: { use: jest.fn() },
+        response: { use: jest.fn() }
+      }
+    };
+
+    mockAuth = {
+      getAccessToken: jest.fn().mockResolvedValue('fake-token'),
+      getInstanceUrl: jest.fn().mockReturnValue('https://test.salesforce.com')
+    } as any;
+
+    MockedSalesforceAuth.mockImplementation(() => mockAuth);
+    mockedAxios.create.mockReturnValue(mockHttpClient);
+
+    client = new SalesforceToolingClient(config);
+  });
+
+  describe('constructor', () => {
+    it('should create a SalesforceToolingClient instance', () => {
+      expect(client).toBeInstanceOf(SalesforceToolingClient);
+      expect(MockedSalesforceAuth).toHaveBeenCalledWith(config);
+      expect(mockedAxios.create).toHaveBeenCalledWith({
+        timeout: 30000,
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+      });
+    });
+
+    it('should setup interceptors', () => {
+      expect(mockHttpClient.interceptors.request.use).toHaveBeenCalled();
+      expect(mockHttpClient.interceptors.response.use).toHaveBeenCalled();
+    });
+  });
+
+  describe('query', () => {
+    it('should execute SOQL query', async () => {
+      const mockResponse = {
+        data: {
+          totalSize: 1,
+          done: true,
+          records: [{ Id: '123', Name: 'TestClass' }]
+        }
+      };
+
+      mockHttpClient.get.mockResolvedValue(mockResponse);
+
+      const result = await client.query('SELECT Id, Name FROM ApexClass');
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith('query/', {
+        params: { q: 'SELECT Id, Name FROM ApexClass' }
+      });
+      expect(result).toEqual(mockResponse.data);
+    });
+  });
+
+  describe('queryMore', () => {
+    it('should execute queryMore', async () => {
+      const mockResponse = {
+        data: {
+          totalSize: 1,
+          done: true,
+          records: [{ Id: '456', Name: 'TestClass2' }]
+        }
+      };
+
+      mockHttpClient.get.mockResolvedValue(mockResponse);
+
+      const result = await client.queryMore('/services/data/v59.0/tooling/queryMore/...');
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith('/services/data/v59.0/tooling/queryMore/...');
+      expect(result).toEqual(mockResponse.data);
+    });
+  });
+
+  describe('describe', () => {
+    it('should describe sobject type', async () => {
+      const mockResponse = {
+        data: {
+          name: 'ApexClass',
+          fields: []
+        }
+      };
+
+      mockHttpClient.get.mockResolvedValue(mockResponse);
+
+      const result = await client.describe('ApexClass');
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith('sobjects/ApexClass/describe/');
+      expect(result).toEqual(mockResponse.data);
+    });
+  });
+
+  describe('create', () => {
+    it('should create a new record', async () => {
+      const mockResponse = {
+        data: {
+          id: '123',
+          success: true,
+          errors: []
+        }
+      };
+
+      mockHttpClient.post.mockResolvedValue(mockResponse);
+
+      const data = { Name: 'TestClass', Body: 'public class TestClass {}' };
+      const result = await client.create('ApexClass', data);
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith('sobjects/ApexClass/', data);
+      expect(result).toEqual(mockResponse.data);
+    });
+  });
+
+  describe('get', () => {
+    it('should get a record by id', async () => {
+      const mockResponse = {
+        data: { Id: '123', Name: 'TestClass', Body: 'public class TestClass {}' }
+      };
+
+      mockHttpClient.get.mockResolvedValue(mockResponse);
+
+      const result = await client.get('ApexClass', '123');
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith('sobjects/ApexClass/123', { params: {} });
+      expect(result).toEqual(mockResponse.data);
+    });
+
+    it('should get a record with specific fields', async () => {
+      const mockResponse = {
+        data: { Id: '123', Name: 'TestClass' }
+      };
+
+      mockHttpClient.get.mockResolvedValue(mockResponse);
+
+      const result = await client.get('ApexClass', '123', ['Id', 'Name']);
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith('sobjects/ApexClass/123', {
+        params: { fields: 'Id,Name' }
+      });
+      expect(result).toEqual(mockResponse.data);
+    });
+  });
+
+  describe('update', () => {
+    it('should update a record', async () => {
+      mockHttpClient.patch.mockResolvedValue({ data: {} });
+
+      const data = { Body: 'public class UpdatedTestClass {}' };
+      await client.update('ApexClass', '123', data);
+
+      expect(mockHttpClient.patch).toHaveBeenCalledWith('sobjects/ApexClass/123', data);
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete a record', async () => {
+      mockHttpClient.delete.mockResolvedValue({ data: {} });
+
+      await client.delete('ApexClass', '123');
+
+      expect(mockHttpClient.delete).toHaveBeenCalledWith('sobjects/ApexClass/123');
+    });
+  });
+
+  describe('getApexClasses', () => {
+    it('should get all apex classes', async () => {
+      const mockResponse = {
+        data: {
+          records: [
+            { Id: '123', Name: 'TestClass1', Body: 'public class TestClass1 {}' },
+            { Id: '456', Name: 'TestClass2', Body: 'public class TestClass2 {}' }
+          ]
+        }
+      };
+
+      mockHttpClient.get.mockResolvedValue(mockResponse);
+
+      const result = await client.getApexClasses();
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith('query/', {
+        params: { 
+          q: 'SELECT Id, Name, Body, NamespacePrefix, ApiVersion, Status, IsValid, BodyCrc, LengthWithoutComments, LastModifiedDate, CreatedDate FROM ApexClass ORDER BY Name'
+        }
+      });
+      expect(result).toEqual(mockResponse.data.records);
+    });
+
+    it('should get apex classes with name filter', async () => {
+      const mockResponse = {
+        data: {
+          records: [
+            { Id: '123', Name: 'TestClass', Body: 'public class TestClass {}' }
+          ]
+        }
+      };
+
+      mockHttpClient.get.mockResolvedValue(mockResponse);
+
+      const result = await client.getApexClasses('Test');
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith('query/', {
+        params: { 
+          q: "SELECT Id, Name, Body, NamespacePrefix, ApiVersion, Status, IsValid, BodyCrc, LengthWithoutComments, LastModifiedDate, CreatedDate FROM ApexClass WHERE Name LIKE '%Test%' ORDER BY Name"
+        }
+      });
+      expect(result).toEqual(mockResponse.data.records);
+    });
+  });
+
+  describe('getApexClass', () => {
+    it('should get a specific apex class', async () => {
+      const mockResponse = {
+        data: { Id: '123', Name: 'TestClass', Body: 'public class TestClass {}' }
+      };
+
+      mockHttpClient.get.mockResolvedValue(mockResponse);
+
+      const result = await client.getApexClass('123');
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith('sobjects/ApexClass/123', { params: {} });
+      expect(result).toEqual(mockResponse.data);
+    });
+  });
+
+  describe('createApexClass', () => {
+    it('should create a new apex class', async () => {
+      const mockResponse = {
+        data: {
+          id: '123',
+          success: true,
+          errors: []
+        }
+      };
+
+      mockHttpClient.post.mockResolvedValue(mockResponse);
+
+      const result = await client.createApexClass('TestClass', 'public class TestClass {}');
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith('sobjects/ApexClass/', {
+        Name: 'TestClass',
+        Body: 'public class TestClass {}'
+      });
+      expect(result).toEqual(mockResponse.data);
+    });
+  });
+
+  describe('updateApexClass', () => {
+    it('should update an apex class', async () => {
+      mockHttpClient.patch.mockResolvedValue({ data: {} });
+
+      await client.updateApexClass('123', 'public class UpdatedTestClass {}');
+
+      expect(mockHttpClient.patch).toHaveBeenCalledWith('sobjects/ApexClass/123', {
+        Body: 'public class UpdatedTestClass {}'
+      });
+    });
+  });
+
+  describe('deleteApexClass', () => {
+    it('should delete an apex class', async () => {
+      mockHttpClient.delete.mockResolvedValue({ data: {} });
+
+      await client.deleteApexClass('123');
+
+      expect(mockHttpClient.delete).toHaveBeenCalledWith('sobjects/ApexClass/123');
+    });
+  });
+
+  describe('getCodeCoverage', () => {
+    it('should get code coverage for all classes', async () => {
+      const mockResponse = {
+        data: {
+          records: [
+            {
+              ApexClassOrTriggerId: '123',
+              ApexClassOrTriggerName: 'TestClass',
+              NumLinesCovered: 10,
+              NumLinesUncovered: 5,
+              Coverage: { coveredLines: [1, 2, 3], uncoveredLines: [4, 5] }
+            }
+          ]
+        }
+      };
+
+      mockHttpClient.get.mockResolvedValue(mockResponse);
+
+      const result = await client.getCodeCoverage();
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith('query/', {
+        params: { 
+          q: 'SELECT ApexClassOrTriggerId, ApexClassOrTriggerName, NumLinesCovered, NumLinesUncovered, Coverage FROM ApexCodeCoverageAggregate'
+        }
+      });
+      expect(result).toEqual(mockResponse.data.records);
+    });
+
+    it('should get code coverage for specific class', async () => {
+      const mockResponse = {
+        data: {
+          records: [
+            {
+              ApexClassOrTriggerId: '123',
+              ApexClassOrTriggerName: 'TestClass',
+              NumLinesCovered: 10,
+              NumLinesUncovered: 5,
+              Coverage: { coveredLines: [1, 2, 3], uncoveredLines: [4, 5] }
+            }
+          ]
+        }
+      };
+
+      mockHttpClient.get.mockResolvedValue(mockResponse);
+
+      const result = await client.getCodeCoverage('123');
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith('query/', {
+        params: { 
+          q: "SELECT ApexClassOrTriggerId, ApexClassOrTriggerName, NumLinesCovered, NumLinesUncovered, Coverage FROM ApexCodeCoverageAggregate WHERE ApexClassOrTriggerId = '123'"
+        }
+      });
+      expect(result).toEqual(mockResponse.data.records);
+    });
+  });
+
+  describe('runTests', () => {
+    it('should run tests', async () => {
+      const mockResponse = {
+        data: { AsyncApexJobId: 'job123' }
+      };
+
+      mockHttpClient.post.mockResolvedValue(mockResponse);
+
+      const result = await client.runTests(['class123', 'class456']);
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith('runTestsAsynchronous/', {
+        tests: [{ classId: 'class123' }, { classId: 'class456' }],
+        maxFailedTests: 1
+      });
+      expect(result).toEqual(mockResponse.data);
+    });
+
+    it('should run tests without class ids', async () => {
+      const mockResponse = {
+        data: { AsyncApexJobId: 'job123' }
+      };
+
+      mockHttpClient.post.mockResolvedValue(mockResponse);
+
+      const result = await client.runTests();
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith('runTestsAsynchronous/', {
+        tests: [],
+        maxFailedTests: 1
+      });
+      expect(result).toEqual(mockResponse.data);
+    });
+  });
+
+  describe('getTestResults', () => {
+    it('should get test results', async () => {
+      const mockResponse = {
+        data: {
+          records: [{
+            Id: 'job123',
+            Status: 'Completed',
+            JobItemsProcessed: 5,
+            TotalJobItems: 5,
+            NumberOfErrors: 0
+          }]
+        }
+      };
+
+      mockHttpClient.get.mockResolvedValue(mockResponse);
+
+      const result = await client.getTestResults('job123');
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith('query/', {
+        params: { 
+          q: "SELECT Id, Status, JobItemsProcessed, TotalJobItems, NumberOfErrors FROM AsyncApexJob WHERE Id = 'job123'"
+        }
+      });
+      expect(result).toEqual(mockResponse.data.records[0]);
+    });
+  });
+
+  describe('getOrgInfo', () => {
+    it('should get organization info', async () => {
+      const mockResponse = {
+        data: {
+          records: [{
+            Id: '00D123456789012',
+            Name: 'Test Org',
+            OrganizationType: 'Developer Edition',
+            InstanceName: 'CS123',
+            IsSandbox: false
+          }]
+        }
+      };
+
+      mockedAxios.get.mockResolvedValue(mockResponse);
+
+      const result = await client.getOrgInfo();
+
+      expect(mockAuth.getAccessToken).toHaveBeenCalled();
+      expect(mockAuth.getInstanceUrl).toHaveBeenCalled();
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        'https://test.salesforce.com/services/data/v59.0/query',
+        {
+          params: {
+            q: 'SELECT Id, Name, OrganizationType, InstanceName, IsSandbox FROM Organization LIMIT 1'
+          },
+          headers: {
+            'Authorization': 'Bearer fake-token',
+            'Content-Type': 'application/json',
+            'Accept': 'application/json'
+          }
+        }
+      );
+      expect(result).toEqual(mockResponse.data.records[0]);
+    });
+  });
+});


### PR DESCRIPTION
- Created comprehensive test suite for SalesforceRestClient covering API calls, limits, and SObject operations.
- Implemented unit tests for SalesforceToolingClient including SOQL queries, record management, and code coverage retrieval.
- Updated package.json to include necessary devDependencies for testing with Jest and TypeScript.