### PR TITLE
chore: update SOQL queries in AsyncApexJob methods to exclude null Ids

### DIFF
--- a/src/client/__tests__/rest-client.test.ts
+++ b/src/client/__tests__/rest-client.test.ts
@@ -394,7 +394,7 @@ describe('SalesforceRestClient', () => {
       const result = await client.searchAsyncApexJobs(searchParams);
 
       expect(mockToolingClient.query).toHaveBeenCalledWith(
-        "SELECT Id, Status, JobType, MethodName, JobItemsProcessed, TotalJobItems, NumberOfErrors, CompletedDate, CreatedDate, CreatedBy.Name, ApexClass.Name FROM AsyncApexJob WHERE 1=1 AND Status = 'Completed' AND JobType = 'BatchApex' AND ApexClass.Name LIKE '%TestBatch%' AND CreatedDate >= 2023-01-01T00:00:00Z AND CreatedDate <= 2023-12-31T23:59:59Z ORDER BY CreatedDate DESC LIMIT 50"
+        "SELECT Id, Status, JobType, MethodName, JobItemsProcessed, TotalJobItems, NumberOfErrors, CompletedDate, CreatedDate, CreatedBy.Name, ApexClass.Name FROM AsyncApexJob WHERE Id != NULL AND Status = 'Completed' AND JobType = 'BatchApex' AND ApexClass.Name LIKE '%TestBatch%' AND CreatedDate >= 2023-01-01T00:00:00Z AND CreatedDate <= 2023-12-31T23:59:59Z ORDER BY CreatedDate DESC LIMIT 50"
       );
       expect(result).toEqual(mockResponse.records);
     });
@@ -406,7 +406,7 @@ describe('SalesforceRestClient', () => {
       const result = await client.searchAsyncApexJobs({});
 
       expect(mockToolingClient.query).toHaveBeenCalledWith(
-        'SELECT Id, Status, JobType, MethodName, JobItemsProcessed, TotalJobItems, NumberOfErrors, CompletedDate, CreatedDate, CreatedBy.Name, ApexClass.Name FROM AsyncApexJob WHERE 1=1 ORDER BY CreatedDate DESC LIMIT 100'
+        'SELECT Id, Status, JobType, MethodName, JobItemsProcessed, TotalJobItems, NumberOfErrors, CompletedDate, CreatedDate, CreatedBy.Name, ApexClass.Name FROM AsyncApexJob WHERE Id != NULL ORDER BY CreatedDate DESC LIMIT 100'
       );
       expect(result).toEqual(mockResponse.records);
     });

--- a/src/client/rest-client.ts
+++ b/src/client/rest-client.ts
@@ -157,7 +157,7 @@ export class SalesforceRestClient {
     createdDateTo?: string;
     limit?: number;
   }): Promise<any[]> {
-    let soql = 'SELECT Id, Status, JobType, MethodName, JobItemsProcessed, TotalJobItems, NumberOfErrors, CompletedDate, CreatedDate, CreatedBy.Name, ApexClass.Name FROM AsyncApexJob WHERE 1=1';
+    let soql = 'SELECT Id, Status, JobType, MethodName, JobItemsProcessed, TotalJobItems, NumberOfErrors, CompletedDate, CreatedDate, CreatedBy.Name, ApexClass.Name FROM AsyncApexJob WHERE Id != NULL';
     
     if (searchParams.status) {
       soql += ` AND Status = '${searchParams.status}'`;


### PR DESCRIPTION
This pull request updates the SOQL query logic in the `SalesforceRestClient` to improve query accuracy and clarity. The key change is replacing the placeholder condition `1=1` with a more explicit `Id != NULL` filter in both the implementation and related tests.

Query logic improvements:

* Updated the base SOQL query in `SalesforceRestClient.searchAsyncApexJobs` to use `WHERE Id != NULL` instead of `WHERE 1=1`, making the query more explicit and semantically correct. (`src/client/rest-client.ts`)
* Updated related test assertions to expect the new `WHERE Id != NULL` condition in the SOQL queries, ensuring tests accurately reflect the implementation. (`src/client/__tests__/rest-client.test.ts`) [[1]](diffhunk://#diff-6bee74f5f1371afe73d2b40abd9296d08d6148aec95ec438827d63a8787653f5L397-R397) [[2]](diffhunk://#diff-6bee74f5f1371afe73d2b40abd9296d08d6148aec95ec438827d63a8787653f5L409-R409)