### PR TITLE
chore: update version to 0.1.8 and fix SOQL query to use correct fiel…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforce-mcp-server",
-  "version": "0.1.6",
+  "version": "0.1.8",
   "description": "MCP server for Salesforce Tooling API integration",
   "type": "module",
   "main": "./build/index.js",

--- a/src/client/__tests__/tooling-client.test.ts
+++ b/src/client/__tests__/tooling-client.test.ts
@@ -349,7 +349,7 @@ describe('SalesforceToolingClient', () => {
 
       expect(mockHttpClient.get).toHaveBeenCalledWith('query/', {
         params: { 
-          q: "SELECT ApexClassOrTriggerId, ApexClassOrTriggerName, NumLinesCovered, NumLinesUncovered, Coverage FROM ApexCodeCoverageAggregate WHERE ApexClassOrTriggerId = '123'"
+          q: "SELECT ApexClassOrTriggerId, ApexClassOrTrigger.Name, NumLinesCovered, NumLinesUncovered, Coverage FROM ApexCodeCoverageAggregate WHERE ApexClassOrTriggerId = '123'"
         }
       });
       expect(result).toEqual(mockResponse.data.records);

--- a/src/client/tooling-client.ts
+++ b/src/client/tooling-client.ts
@@ -229,7 +229,7 @@ export class SalesforceToolingClient {
     apexClassOrTriggerId?: string
   ): Promise<CodeCoverage[]> {
     let soql =
-      'SELECT ApexClassOrTriggerId, ApexClassOrTriggerName, NumLinesCovered, NumLinesUncovered, Coverage FROM ApexCodeCoverageAggregate';
+      'SELECT ApexClassOrTriggerId, ApexClassOrTrigger.Name, NumLinesCovered, NumLinesUncovered, Coverage FROM ApexCodeCoverageAggregate';
 
     if (apexClassOrTriggerId) {
       soql += ` WHERE ApexClassOrTriggerId = '${apexClassOrTriggerId}'`;


### PR DESCRIPTION
This pull request makes a small but important fix to how code coverage data is queried from Salesforce, ensuring the correct field is selected in SOQL queries. It also bumps the package version to reflect this change.

Salesforce Tooling API Query Fixes:

* Updated the SOQL query in `SalesforceToolingClient` to select `ApexClassOrTrigger.Name` instead of the incorrect `ApexClassOrTriggerName` field, ensuring compatibility with Salesforce's schema.
* Updated the corresponding unit test to expect the correct SOQL query, maintaining test accuracy.

Versioning:

* Bumped the package version in `package.json` from `0.1.6` to `0.1.8` to reflect the bugfix.