### PR TITLE
chore: update version to 0.1.9 and modify SOQL query and CodeCoverage…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforce-mcp-server",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "MCP server for Salesforce Tooling API integration",
   "type": "module",
   "main": "./build/index.js",

--- a/src/client/__tests__/tooling-client.test.ts
+++ b/src/client/__tests__/tooling-client.test.ts
@@ -322,7 +322,7 @@ describe('SalesforceToolingClient', () => {
 
       expect(mockHttpClient.get).toHaveBeenCalledWith('query/', {
         params: { 
-          q: 'SELECT ApexClassOrTriggerId, ApexClassOrTriggerName, NumLinesCovered, NumLinesUncovered, Coverage FROM ApexCodeCoverageAggregate'
+          q: 'SELECT ApexClassOrTriggerId, ApexClassOrTrigger.Name, NumLinesCovered, NumLinesUncovered, Coverage FROM ApexCodeCoverageAggregate'
         }
       });
       expect(result).toEqual(mockResponse.data.records);

--- a/src/client/tooling-client.ts
+++ b/src/client/tooling-client.ts
@@ -31,7 +31,6 @@ export class SalesforceToolingClient {
   private setupInterceptors(): void {
     this.httpClient.interceptors.request.use(async (config) => {
       const token = await this.auth.getAccessToken();
-      console.log(token);
       const instanceUrl = this.auth.getInstanceUrl();
 
       config.headers.Authorization = `Bearer ${token}`;
@@ -235,8 +234,21 @@ export class SalesforceToolingClient {
       soql += ` WHERE ApexClassOrTriggerId = '${apexClassOrTriggerId}'`;
     }
 
-    const result = await this.query<CodeCoverage>(soql);
-    return result.records;
+    console.log('Debug - getCodeCoverage SOQL:', soql);
+    
+    try {
+      const result = await this.query<CodeCoverage>(soql);
+      console.log('Debug - getCodeCoverage result:', JSON.stringify(result, null, 2));
+      return result.records;
+    } catch (error: any) {
+      console.error('Debug - getCodeCoverage error:', {
+        status: error.response?.status,
+        statusText: error.response?.statusText,
+        data: error.response?.data,
+        message: error.message
+      });
+      throw error;
+    }
   }
 
   // Symbol Table methods

--- a/src/tools/code-coverage-tools.ts
+++ b/src/tools/code-coverage-tools.ts
@@ -18,7 +18,7 @@ export function createCodeCoverageTools(client: SalesforceToolingClient) {
               type: 'text',
               text: `Code Coverage (${filtered.length} items):\n\n${filtered.map(c => {
                 const percentage = ((c.NumLinesCovered / (c.NumLinesCovered + c.NumLinesUncovered)) * 100).toFixed(1);
-                return `• ${c.ApexClassOrTriggerName}: ${percentage}% (${c.NumLinesCovered}/${c.NumLinesCovered + c.NumLinesUncovered})`;
+                return `• ${c.ApexClassOrTrigger.Name}: ${percentage}% (${c.NumLinesCovered}/${c.NumLinesCovered + c.NumLinesUncovered})`;
               }).join('\n')}`
             }]
           };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -95,7 +95,7 @@ export interface ApexPage {
 
 export interface CodeCoverage {
   ApexClassOrTriggerId: string;
-  ApexClassOrTriggerName: string;
+  ApexClassOrTrigger: { Name: string };
   NumLinesCovered: number;
   NumLinesUncovered: number;
   Coverage: {


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the Salesforce code coverage tooling, primarily updating the way code coverage data is queried, handled, and displayed. The changes focus on aligning with Salesforce's data model, improving debugging, and cleaning up unnecessary code.

**Salesforce Code Coverage Handling:**

* Updated the SOQL query and data model to use the nested `ApexClassOrTrigger.Name` field instead of the flat `ApexClassOrTriggerName`, ensuring compatibility with Salesforce's API. [[1]](diffhunk://#diff-a3ee0ee79a84330c5e32d564895e2641185638676bf5b66a8b6d4fa9d9468b42L325-R325) [[2]](diffhunk://#diff-a9ba9cbedd19c9f66d564d2e89912890209b98f0a7ef19187877d2587300e476L98-R98)
* Updated code coverage display logic to reference `ApexClassOrTrigger.Name` in the output, matching the new data structure.

**Debugging and Logging:**

* Added debug logging to the `getCodeCoverage` method to print the generated SOQL query, the query result, and detailed error information to aid troubleshooting.
* Removed an unnecessary console log of the access token from the request interceptor for cleaner logs and improved security.

**General Maintenance:**

* Bumped the package version from `0.1.8` to `0.1.9` to reflect the new changes.