### PR TITLE
Feature/use connection to request

### DIFF
--- a/src/auth/salesforce-auth.ts
+++ b/src/auth/salesforce-auth.ts
@@ -15,7 +15,7 @@ export class SalesforceAuth {
   }
 
   async getAccessToken(): Promise<string> {
-    const connection = await this.getConnection();
+    const connection = await this.getConnectionInternal();
     const accessToken = connection.accessToken;
     if (!accessToken) {
       throw new Error('No access token available');
@@ -30,7 +30,21 @@ export class SalesforceAuth {
     return this.config.instanceUrl;
   }
 
-  private async getConnection(): Promise<Connection> {
+  async getConnection(): Promise<Connection> {
+    return await this.getConnectionInternal();
+  }
+
+  async toolingRequest(url: string, options?: any): Promise<any> {
+    const connection = await this.getConnectionInternal();
+    return await connection.tooling.request(url, options);
+  }
+
+  async restRequest(url: string, options?: any): Promise<any> {
+    const connection = await this.getConnectionInternal();
+    return await connection.request(url, options);
+  }
+
+  private async getConnectionInternal(): Promise<Connection> {
     // Use AuthInfo-based authentication
     await this.authenticateWithAuthInfo();
 

--- a/src/auth/salesforce-auth.ts
+++ b/src/auth/salesforce-auth.ts
@@ -3,7 +3,6 @@ import { SalesforceConfig } from '../types/index.js';
 
 export class SalesforceAuth {
   private config: SalesforceConfig;
-  private connection?: Connection;
 
   constructor(config: SalesforceConfig) {
     this.config = config;
@@ -14,49 +13,17 @@ export class SalesforceAuth {
     return new SalesforceAuth(config);
   }
 
-  async getAccessToken(): Promise<string> {
-    const connection = await this.getConnectionInternal();
-    const accessToken = connection.accessToken;
-    if (!accessToken) {
-      throw new Error('No access token available');
-    }
-    return accessToken;
-  }
-
-  getInstanceUrl(): string {
-    if (this.connection) {
-      return this.connection.instanceUrl;
-    }
-    return this.config.instanceUrl;
-  }
-
-  async getConnection(): Promise<Connection> {
-    return await this.getConnectionInternal();
-  }
-
   async toolingRequest(url: string, options?: any): Promise<any> {
-    const connection = await this.getConnectionInternal();
+    const connection = await this.getConnection();
     return await connection.tooling.request(url, options);
   }
 
   async restRequest(url: string, options?: any): Promise<any> {
-    const connection = await this.getConnectionInternal();
+    const connection = await this.getConnection();
     return await connection.request(url, options);
   }
 
-  private async getConnectionInternal(): Promise<Connection> {
-    // Use AuthInfo-based authentication
-    await this.authenticateWithAuthInfo();
-
-    if (!this.connection) {
-      throw new Error('Failed to establish connection');
-    }
-
-    return this.connection;
-  }
-
-
-  private async authenticateWithAuthInfo(): Promise<void> {
+  private async getConnection(): Promise<Connection> {
     try {
       let targetAuthInfo: AuthInfo;
 
@@ -79,12 +46,13 @@ export class SalesforceAuth {
         targetAuthInfo = await AuthInfo.create();
       }
 
-      // Create connection using AuthInfo
-      this.connection = await Connection.create({ authInfo: targetAuthInfo });
+      // Create connection and return directly without caching
+      return await Connection.create({ authInfo: targetAuthInfo });
 
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : 'Unknown error';
       throw new Error(`Failed to authenticate with AuthInfo: ${message}`);
     }
   }
+
 }

--- a/src/client/__tests__/rest-client.test.ts
+++ b/src/client/__tests__/rest-client.test.ts
@@ -1,17 +1,13 @@
-import axios from 'axios';
 import { SalesforceRestClient } from '../rest-client';
 import { SalesforceAuth } from '../../auth/salesforce-auth';
 import { SalesforceConfig } from '../../types/index';
 
-jest.mock('axios');
 jest.mock('../../auth/salesforce-auth');
 
-const mockedAxios = axios as jest.Mocked<typeof axios>;
 const MockedSalesforceAuth = SalesforceAuth as jest.MockedClass<typeof SalesforceAuth>;
 
 describe('SalesforceRestClient', () => {
   let client: SalesforceRestClient;
-  let mockHttpClient: any;
   let mockAuth: jest.Mocked<SalesforceAuth>;
   let config: SalesforceConfig;
 
@@ -26,25 +22,14 @@ describe('SalesforceRestClient', () => {
       apiVersion: '59.0'
     };
 
-    mockHttpClient = jest.fn().mockImplementation(() => Promise.resolve({ data: {} }));
-    Object.assign(mockHttpClient, {
-      get: jest.fn(),
-      post: jest.fn(),
-      patch: jest.fn(),
-      delete: jest.fn(),
-      interceptors: {
-        request: { use: jest.fn() },
-        response: { use: jest.fn() }
-      }
-    });
-
     mockAuth = {
       getAccessToken: jest.fn().mockResolvedValue('fake-token'),
-      getInstanceUrl: jest.fn().mockReturnValue('https://test.salesforce.com')
+      getInstanceUrl: jest.fn().mockReturnValue('https://test.salesforce.com'),
+      restRequest: jest.fn().mockResolvedValue({}),
+      getConnection: jest.fn().mockResolvedValue({})
     } as any;
 
     MockedSalesforceAuth.mockImplementation(() => mockAuth);
-    mockedAxios.create.mockReturnValue(mockHttpClient);
 
     client = new SalesforceRestClient(config);
   });
@@ -53,257 +38,201 @@ describe('SalesforceRestClient', () => {
     it('should create a SalesforceRestClient instance', () => {
       expect(client).toBeInstanceOf(SalesforceRestClient);
       expect(MockedSalesforceAuth).toHaveBeenCalledWith(config);
-      expect(mockedAxios.create).toHaveBeenCalledWith({
-        timeout: 30000,
-        headers: {
-          'Content-Type': 'application/json',
-          Accept: 'application/json',
-        },
-      });
-    });
-
-    it('should setup interceptors', () => {
-      expect(mockHttpClient.interceptors.request.use).toHaveBeenCalled();
-      expect(mockHttpClient.interceptors.response.use).toHaveBeenCalled();
     });
   });
 
   describe('callApi', () => {
     it('should make GET request', async () => {
-      const mockResponse = { data: { success: true } };
-      mockHttpClient.mockResolvedValue(mockResponse);
+      const mockResponse = { success: true };
+      mockAuth.restRequest.mockResolvedValue(mockResponse);
 
       const result = await client.callApi('sobjects');
 
-      expect(mockHttpClient).toHaveBeenCalledWith({
-        method: 'GET',
-        url: 'sobjects',
-        params: undefined
-      });
-      expect(result).toEqual(mockResponse.data);
+      expect(mockAuth.restRequest).toHaveBeenCalledWith('sobjects', { method: 'GET' });
+      expect(result).toEqual(mockResponse);
     });
 
     it('should make POST request with body', async () => {
-      const mockResponse = { data: { id: '123', success: true } };
+      const mockResponse = { id: '123', success: true };
       const requestBody = { Name: 'Test Account' };
-      
-      mockHttpClient.mockResolvedValue(mockResponse);
+
+      mockAuth.restRequest.mockResolvedValue(mockResponse);
 
       const result = await client.callApi('sobjects/Account', 'POST', requestBody);
 
-      expect(mockHttpClient).toHaveBeenCalledWith({
+      expect(mockAuth.restRequest).toHaveBeenCalledWith('sobjects/Account', {
         method: 'POST',
-        url: 'sobjects/Account',
-        params: undefined,
-        data: requestBody
+        body: JSON.stringify(requestBody),
+        headers: { 'Content-Type': 'application/json' }
       });
-      expect(result).toEqual(mockResponse.data);
+      expect(result).toEqual(mockResponse);
     });
 
     it('should make PATCH request with body', async () => {
-      const mockResponse = { data: {} };
+      const mockResponse = {};
       const requestBody = { Name: 'Updated Account' };
-      
-      mockHttpClient.mockResolvedValue(mockResponse);
+
+      mockAuth.restRequest.mockResolvedValue(mockResponse);
 
       const result = await client.callApi('sobjects/Account/123', 'PATCH', requestBody);
 
-      expect(mockHttpClient).toHaveBeenCalledWith({
+      expect(mockAuth.restRequest).toHaveBeenCalledWith('sobjects/Account/123', {
         method: 'PATCH',
-        url: 'sobjects/Account/123',
-        params: undefined,
-        data: requestBody
+        body: JSON.stringify(requestBody),
+        headers: { 'Content-Type': 'application/json' }
       });
-      expect(result).toEqual(mockResponse.data);
+      expect(result).toEqual(mockResponse);
     });
 
     it('should make DELETE request', async () => {
-      const mockResponse = { data: {} };
-      
-      mockHttpClient.mockResolvedValue(mockResponse);
+      const mockResponse = {};
+
+      mockAuth.restRequest.mockResolvedValue(mockResponse);
 
       const result = await client.callApi('sobjects/Account/123', 'DELETE');
 
-      expect(mockHttpClient).toHaveBeenCalledWith({
-        method: 'DELETE',
-        url: 'sobjects/Account/123',
-        params: undefined
-      });
-      expect(result).toEqual(mockResponse.data);
+      expect(mockAuth.restRequest).toHaveBeenCalledWith('sobjects/Account/123', { method: 'DELETE' });
+      expect(result).toEqual(mockResponse);
     });
 
     it('should include query parameters', async () => {
-      const mockResponse = { data: { records: [] } };
+      const mockResponse = { records: [] };
       const params = { q: 'SELECT Id FROM Account' };
-      
-      mockHttpClient.mockResolvedValue(mockResponse);
+
+      mockAuth.restRequest.mockResolvedValue(mockResponse);
 
       const result = await client.callApi('query', 'GET', null, params);
 
-      expect(mockHttpClient).toHaveBeenCalledWith({
-        method: 'GET',
-        url: 'query',
-        params: params
-      });
-      expect(result).toEqual(mockResponse.data);
+      expect(mockAuth.restRequest).toHaveBeenCalledWith('query?q=SELECT+Id+FROM+Account', { method: 'GET' });
+      expect(result).toEqual(mockResponse);
     });
   });
 
   describe('getLimits', () => {
     it('should get organization limits', async () => {
-      const mockResponse = { data: { DailyApiRequests: { Remaining: 100000, Max: 100000 } } };
-      mockHttpClient.mockResolvedValue(mockResponse);
+      const mockResponse = { DailyApiRequests: { Remaining: 100000, Max: 100000 } };
+      mockAuth.restRequest.mockResolvedValue(mockResponse);
 
       const result = await client.getLimits();
 
-      expect(mockHttpClient).toHaveBeenCalledWith({
-        method: 'GET',
-        url: 'limits',
-        params: undefined
-      });
-      expect(result).toEqual(mockResponse.data);
+      expect(mockAuth.restRequest).toHaveBeenCalledWith('limits', { method: 'GET' });
+      expect(result).toEqual(mockResponse);
     });
   });
 
   describe('getSObjects', () => {
     it('should get all sobjects', async () => {
-      const mockResponse = { data: { sobjects: [{ name: 'Account' }, { name: 'Contact' }] } };
-      mockHttpClient.mockResolvedValue(mockResponse);
+      const mockResponse = { sobjects: [{ name: 'Account' }, { name: 'Contact' }] };
+      mockAuth.restRequest.mockResolvedValue(mockResponse);
 
       const result = await client.getSObjects();
 
-      expect(mockHttpClient).toHaveBeenCalledWith({
-        method: 'GET',
-        url: 'sobjects',
-        params: undefined
-      });
-      expect(result).toEqual(mockResponse.data);
+      expect(mockAuth.restRequest).toHaveBeenCalledWith('sobjects', { method: 'GET' });
+      expect(result).toEqual(mockResponse);
     });
   });
 
   describe('describeSObject', () => {
     it('should describe sobject', async () => {
-      const mockResponse = { data: { name: 'Account', fields: [] } };
-      mockHttpClient.mockResolvedValue(mockResponse);
+      const mockResponse = { name: 'Account', fields: [] };
+      mockAuth.restRequest.mockResolvedValue(mockResponse);
 
       const result = await client.describeSObject('Account');
 
-      expect(mockHttpClient).toHaveBeenCalledWith({
-        method: 'GET',
-        url: 'sobjects/Account/describe',
-        params: undefined
-      });
-      expect(result).toEqual(mockResponse.data);
+      expect(mockAuth.restRequest).toHaveBeenCalledWith('sobjects/Account/describe', { method: 'GET' });
+      expect(result).toEqual(mockResponse);
     });
   });
 
   describe('query', () => {
     it('should execute query using REST API', async () => {
-      const mockResponse = { data: { totalSize: 1, done: true, records: [{ Id: '123' }] } };
-      mockHttpClient.mockResolvedValue(mockResponse);
+      const mockResponse = { totalSize: 1, done: true, records: [{ Id: '123' }] };
+      mockAuth.restRequest.mockResolvedValue(mockResponse);
 
       const result = await client.query('SELECT Id FROM Account');
 
-      expect(mockHttpClient).toHaveBeenCalledWith({
-        method: 'GET',
-        url: 'query',
-        params: { q: 'SELECT Id FROM Account' }
-      });
-      expect(result).toEqual(mockResponse.data);
+      expect(mockAuth.restRequest).toHaveBeenCalledWith('query?q=SELECT+Id+FROM+Account', { method: 'GET' });
+      expect(result).toEqual(mockResponse);
     });
   });
 
   describe('queryMore', () => {
     it('should execute queryMore', async () => {
-      const mockResponse = { data: { totalSize: 1, done: true, records: [{ Id: '456' }] } };
-      mockHttpClient.get.mockResolvedValue(mockResponse);
+      const mockResponse = { totalSize: 1, done: true, records: [{ Id: '456' }] };
+      mockAuth.restRequest.mockResolvedValue(mockResponse);
 
       const result = await client.queryMore('/services/data/v59.0/query/123-abc');
 
-      expect(mockHttpClient.get).toHaveBeenCalledWith('/services/data/v59.0/query/123-abc');
-      expect(result).toEqual(mockResponse.data);
+      expect(mockAuth.restRequest).toHaveBeenCalledWith('/services/data/v59.0/query/123-abc');
+      expect(result).toEqual(mockResponse);
     });
   });
 
   describe('createRecord', () => {
     it('should create a record', async () => {
-      const mockResponse = { data: { id: '123', success: true } };
+      const mockResponse = { id: '123', success: true };
       const recordData = { Name: 'Test Account' };
-      
-      mockHttpClient.mockResolvedValue(mockResponse);
+
+      mockAuth.restRequest.mockResolvedValue(mockResponse);
 
       const result = await client.createRecord('Account', recordData);
 
-      expect(mockHttpClient).toHaveBeenCalledWith({
+      expect(mockAuth.restRequest).toHaveBeenCalledWith('sobjects/Account', {
         method: 'POST',
-        url: 'sobjects/Account',
-        params: undefined,
-        data: recordData
+        body: JSON.stringify(recordData),
+        headers: { 'Content-Type': 'application/json' }
       });
-      expect(result).toEqual(mockResponse.data);
+      expect(result).toEqual(mockResponse);
     });
   });
 
   describe('getRecord', () => {
     it('should get a record by id', async () => {
-      const mockResponse = { data: { Id: '123', Name: 'Test Account' } };
-      mockHttpClient.mockResolvedValue(mockResponse);
+      const mockResponse = { Id: '123', Name: 'Test Account' };
+      mockAuth.restRequest.mockResolvedValue(mockResponse);
 
       const result = await client.getRecord('Account', '123');
 
-      expect(mockHttpClient).toHaveBeenCalledWith({
-        method: 'GET',
-        url: 'sobjects/Account/123',
-        params: {}
-      });
-      expect(result).toEqual(mockResponse.data);
+      expect(mockAuth.restRequest).toHaveBeenCalledWith('sobjects/Account/123', { method: 'GET' });
+      expect(result).toEqual(mockResponse);
     });
 
     it('should get a record with specific fields', async () => {
-      const mockResponse = { data: { Id: '123', Name: 'Test Account' } };
-      mockHttpClient.mockResolvedValue(mockResponse);
+      const mockResponse = { Id: '123', Name: 'Test Account' };
+      mockAuth.restRequest.mockResolvedValue(mockResponse);
 
       const result = await client.getRecord('Account', '123', ['Id', 'Name']);
 
-      expect(mockHttpClient).toHaveBeenCalledWith({
-        method: 'GET',
-        url: 'sobjects/Account/123',
-        params: { fields: 'Id,Name' }
-      });
-      expect(result).toEqual(mockResponse.data);
+      expect(mockAuth.restRequest).toHaveBeenCalledWith('sobjects/Account/123?fields=Id%2CName', { method: 'GET' });
+      expect(result).toEqual(mockResponse);
     });
   });
 
   describe('updateRecord', () => {
     it('should update a record', async () => {
-      const mockResponse = { data: {} };
+      const mockResponse = {};
       const updateData = { Name: 'Updated Account' };
-      
-      mockHttpClient.mockResolvedValue(mockResponse);
+
+      mockAuth.restRequest.mockResolvedValue(mockResponse);
 
       await client.updateRecord('Account', '123', updateData);
 
-      expect(mockHttpClient).toHaveBeenCalledWith({
+      expect(mockAuth.restRequest).toHaveBeenCalledWith('sobjects/Account/123', {
         method: 'PATCH',
-        url: 'sobjects/Account/123',
-        params: undefined,
-        data: updateData
+        body: JSON.stringify(updateData),
+        headers: { 'Content-Type': 'application/json' }
       });
     });
   });
 
   describe('deleteRecord', () => {
     it('should delete a record', async () => {
-      const mockResponse = { data: {} };
-      mockHttpClient.mockResolvedValue(mockResponse);
+      const mockResponse = {};
+      mockAuth.restRequest.mockResolvedValue(mockResponse);
 
       await client.deleteRecord('Account', '123');
 
-      expect(mockHttpClient).toHaveBeenCalledWith({
-        method: 'DELETE',
-        url: 'sobjects/Account/123',
-        params: undefined
-      });
+      expect(mockAuth.restRequest).toHaveBeenCalledWith('sobjects/Account/123', { method: 'DELETE' });
     });
   });
 
@@ -322,6 +251,18 @@ describe('SalesforceRestClient', () => {
         instanceUrl: 'https://test.salesforce.com',
         apiVersion: '59.0'
       });
+    });
+  });
+
+  describe('getConnection', () => {
+    it('should get connection instance', async () => {
+      const mockConnection = { instanceUrl: 'https://test.salesforce.com' } as any;
+      mockAuth.getConnection.mockResolvedValue(mockConnection);
+
+      const result = await client.getConnection();
+
+      expect(mockAuth.getConnection).toHaveBeenCalled();
+      expect(result).toEqual(mockConnection);
     });
   });
 });

--- a/src/client/__tests__/rest-client.test.ts
+++ b/src/client/__tests__/rest-client.test.ts
@@ -23,8 +23,6 @@ describe('SalesforceRestClient', () => {
     };
 
     mockAuth = {
-      getAccessToken: jest.fn().mockResolvedValue('fake-token'),
-      getInstanceUrl: jest.fn().mockReturnValue('https://test.salesforce.com'),
       restRequest: jest.fn().mockResolvedValue({}),
       getConnection: jest.fn().mockResolvedValue({})
     } as any;
@@ -115,7 +113,7 @@ describe('SalesforceRestClient', () => {
 
       const result = await client.getLimits();
 
-      expect(mockAuth.restRequest).toHaveBeenCalledWith('limits', { method: 'GET' });
+      expect(mockAuth.restRequest).toHaveBeenCalledWith('/limits', { method: 'GET' });
       expect(result).toEqual(mockResponse);
     });
   });
@@ -127,7 +125,7 @@ describe('SalesforceRestClient', () => {
 
       const result = await client.getSObjects();
 
-      expect(mockAuth.restRequest).toHaveBeenCalledWith('sobjects', { method: 'GET' });
+      expect(mockAuth.restRequest).toHaveBeenCalledWith('/sobjects', { method: 'GET' });
       expect(result).toEqual(mockResponse);
     });
   });
@@ -139,7 +137,7 @@ describe('SalesforceRestClient', () => {
 
       const result = await client.describeSObject('Account');
 
-      expect(mockAuth.restRequest).toHaveBeenCalledWith('sobjects/Account/describe', { method: 'GET' });
+      expect(mockAuth.restRequest).toHaveBeenCalledWith('/sobjects/Account/describe', { method: 'GET' });
       expect(result).toEqual(mockResponse);
     });
   });
@@ -151,7 +149,7 @@ describe('SalesforceRestClient', () => {
 
       const result = await client.query('SELECT Id FROM Account');
 
-      expect(mockAuth.restRequest).toHaveBeenCalledWith('query?q=SELECT+Id+FROM+Account', { method: 'GET' });
+      expect(mockAuth.restRequest).toHaveBeenCalledWith('/query?q=SELECT+Id+FROM+Account', { method: 'GET' });
       expect(result).toEqual(mockResponse);
     });
   });
@@ -177,7 +175,7 @@ describe('SalesforceRestClient', () => {
 
       const result = await client.createRecord('Account', recordData);
 
-      expect(mockAuth.restRequest).toHaveBeenCalledWith('sobjects/Account', {
+      expect(mockAuth.restRequest).toHaveBeenCalledWith('/sobjects/Account', {
         method: 'POST',
         body: JSON.stringify(recordData),
         headers: { 'Content-Type': 'application/json' }
@@ -193,7 +191,7 @@ describe('SalesforceRestClient', () => {
 
       const result = await client.getRecord('Account', '123');
 
-      expect(mockAuth.restRequest).toHaveBeenCalledWith('sobjects/Account/123', { method: 'GET' });
+      expect(mockAuth.restRequest).toHaveBeenCalledWith('/sobjects/Account/123', { method: 'GET' });
       expect(result).toEqual(mockResponse);
     });
 
@@ -203,7 +201,7 @@ describe('SalesforceRestClient', () => {
 
       const result = await client.getRecord('Account', '123', ['Id', 'Name']);
 
-      expect(mockAuth.restRequest).toHaveBeenCalledWith('sobjects/Account/123?fields=Id%2CName', { method: 'GET' });
+      expect(mockAuth.restRequest).toHaveBeenCalledWith('/sobjects/Account/123?fields=Id%2CName', { method: 'GET' });
       expect(result).toEqual(mockResponse);
     });
   });
@@ -217,7 +215,7 @@ describe('SalesforceRestClient', () => {
 
       await client.updateRecord('Account', '123', updateData);
 
-      expect(mockAuth.restRequest).toHaveBeenCalledWith('sobjects/Account/123', {
+      expect(mockAuth.restRequest).toHaveBeenCalledWith('/sobjects/Account/123', {
         method: 'PATCH',
         body: JSON.stringify(updateData),
         headers: { 'Content-Type': 'application/json' }
@@ -232,37 +230,7 @@ describe('SalesforceRestClient', () => {
 
       await client.deleteRecord('Account', '123');
 
-      expect(mockAuth.restRequest).toHaveBeenCalledWith('sobjects/Account/123', { method: 'DELETE' });
-    });
-  });
-
-
-  describe('getAuth', () => {
-    it('should get authentication info', async () => {
-      mockAuth.getAccessToken.mockResolvedValue('test-token');
-      mockAuth.getInstanceUrl.mockReturnValue('https://test.salesforce.com');
-
-      const result = await client.getAuth();
-
-      expect(mockAuth.getAccessToken).toHaveBeenCalled();
-      expect(mockAuth.getInstanceUrl).toHaveBeenCalled();
-      expect(result).toEqual({
-        token: 'test-token',
-        instanceUrl: 'https://test.salesforce.com',
-        apiVersion: '59.0'
-      });
-    });
-  });
-
-  describe('getConnection', () => {
-    it('should get connection instance', async () => {
-      const mockConnection = { instanceUrl: 'https://test.salesforce.com' } as any;
-      mockAuth.getConnection.mockResolvedValue(mockConnection);
-
-      const result = await client.getConnection();
-
-      expect(mockAuth.getConnection).toHaveBeenCalled();
-      expect(result).toEqual(mockConnection);
+      expect(mockAuth.restRequest).toHaveBeenCalledWith('/sobjects/Account/123', { method: 'DELETE' });
     });
   });
 });

--- a/src/client/__tests__/tooling-client.test.ts
+++ b/src/client/__tests__/tooling-client.test.ts
@@ -370,27 +370,6 @@ describe('SalesforceToolingClient', () => {
     });
   });
 
-  describe('getOrgInfo', () => {
-    it('should get organization info', async () => {
-      const mockResponse = {
-        records: [{
-          Id: '00D123456789012',
-          Name: 'Test Org',
-          OrganizationType: 'Developer Edition',
-          InstanceName: 'CS123',
-          IsSandbox: false
-        }]
-      };
-
-      mockAuth.restRequest.mockResolvedValue(mockResponse);
-
-      const result = await client.getOrgInfo();
-
-      expect(mockAuth.restRequest).toHaveBeenCalledWith('query?q=SELECT+Id%2C+Name%2C+OrganizationType%2C+InstanceName%2C+IsSandbox+FROM+Organization+LIMIT+1');
-      expect(result).toEqual(mockResponse.records[0]);
-    });
-  });
-
   describe('getAsyncApexJobs', () => {
     it('should get all async apex jobs', async () => {
       const mockResponse = {

--- a/src/client/__tests__/tooling-client.test.ts
+++ b/src/client/__tests__/tooling-client.test.ts
@@ -1,17 +1,13 @@
-import axios from 'axios';
 import { SalesforceToolingClient } from '../tooling-client';
 import { SalesforceAuth } from '../../auth/salesforce-auth';
 import { SalesforceConfig } from '../../types/index';
 
-jest.mock('axios');
 jest.mock('../../auth/salesforce-auth');
 
-const mockedAxios = axios as jest.Mocked<typeof axios>;
 const MockedSalesforceAuth = SalesforceAuth as jest.MockedClass<typeof SalesforceAuth>;
 
 describe('SalesforceToolingClient', () => {
   let client: SalesforceToolingClient;
-  let mockHttpClient: any;
   let mockAuth: jest.Mocked<SalesforceAuth>;
   let config: SalesforceConfig;
 
@@ -26,24 +22,14 @@ describe('SalesforceToolingClient', () => {
       apiVersion: '59.0'
     };
 
-    mockHttpClient = {
-      get: jest.fn(),
-      post: jest.fn(),
-      patch: jest.fn(),
-      delete: jest.fn(),
-      interceptors: {
-        request: { use: jest.fn() },
-        response: { use: jest.fn() }
-      }
-    };
-
     mockAuth = {
       getAccessToken: jest.fn().mockResolvedValue('fake-token'),
-      getInstanceUrl: jest.fn().mockReturnValue('https://test.salesforce.com')
+      getInstanceUrl: jest.fn().mockReturnValue('https://test.salesforce.com'),
+      toolingRequest: jest.fn().mockResolvedValue({}),
+      restRequest: jest.fn().mockResolvedValue({})
     } as any;
 
     MockedSalesforceAuth.mockImplementation(() => mockAuth);
-    mockedAxios.create.mockReturnValue(mockHttpClient);
 
     client = new SalesforceToolingClient(config);
   });
@@ -52,486 +38,409 @@ describe('SalesforceToolingClient', () => {
     it('should create a SalesforceToolingClient instance', () => {
       expect(client).toBeInstanceOf(SalesforceToolingClient);
       expect(MockedSalesforceAuth).toHaveBeenCalledWith(config);
-      expect(mockedAxios.create).toHaveBeenCalledWith({
-        timeout: 30000,
-        headers: {
-          'Content-Type': 'application/json',
-          Accept: 'application/json',
-        },
-      });
     });
 
     it('should create a SalesforceToolingClient instance with shared auth', () => {
       const sharedAuth = new SalesforceAuth(config);
       const clientWithSharedAuth = new SalesforceToolingClient(config, sharedAuth);
-      
-      expect(clientWithSharedAuth).toBeInstanceOf(SalesforceToolingClient);
-      // Should not create a new auth instance when sharedAuth is provided
-    });
 
-    it('should setup interceptors', () => {
-      expect(mockHttpClient.interceptors.request.use).toHaveBeenCalled();
-      expect(mockHttpClient.interceptors.response.use).toHaveBeenCalled();
+      expect(clientWithSharedAuth).toBeInstanceOf(SalesforceToolingClient);
     });
   });
 
   describe('query', () => {
     it('should execute SOQL query', async () => {
       const mockResponse = {
-        data: {
-          totalSize: 1,
-          done: true,
-          records: [{ Id: '123', Name: 'TestClass' }]
-        }
+        totalSize: 1,
+        done: true,
+        records: [{ Id: '123', Name: 'TestClass' }]
       };
 
-      mockHttpClient.get.mockResolvedValue(mockResponse);
+      mockAuth.toolingRequest.mockResolvedValue(mockResponse);
 
       const result = await client.query('SELECT Id, Name FROM ApexClass');
 
-      expect(mockHttpClient.get).toHaveBeenCalledWith('query/', {
-        params: { q: 'SELECT Id, Name FROM ApexClass' }
-      });
-      expect(result).toEqual(mockResponse.data);
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('query/?q=SELECT+Id%2C+Name+FROM+ApexClass');
+      expect(result).toEqual(mockResponse);
     });
   });
 
   describe('queryMore', () => {
     it('should execute queryMore', async () => {
       const mockResponse = {
-        data: {
-          totalSize: 1,
-          done: true,
-          records: [{ Id: '456', Name: 'TestClass2' }]
-        }
+        totalSize: 1,
+        done: true,
+        records: [{ Id: '456', Name: 'TestClass2' }]
       };
 
-      mockHttpClient.get.mockResolvedValue(mockResponse);
+      mockAuth.toolingRequest.mockResolvedValue(mockResponse);
 
       const result = await client.queryMore('/services/data/v59.0/tooling/queryMore/...');
 
-      expect(mockHttpClient.get).toHaveBeenCalledWith('/services/data/v59.0/tooling/queryMore/...');
-      expect(result).toEqual(mockResponse.data);
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('/services/data/v59.0/tooling/queryMore/...');
+      expect(result).toEqual(mockResponse);
     });
   });
 
   describe('describe', () => {
     it('should describe sobject type', async () => {
       const mockResponse = {
-        data: {
-          name: 'ApexClass',
-          fields: []
-        }
+        name: 'ApexClass',
+        fields: []
       };
 
-      mockHttpClient.get.mockResolvedValue(mockResponse);
+      mockAuth.toolingRequest.mockResolvedValue(mockResponse);
 
       const result = await client.describe('ApexClass');
 
-      expect(mockHttpClient.get).toHaveBeenCalledWith('sobjects/ApexClass/describe/');
-      expect(result).toEqual(mockResponse.data);
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('sobjects/ApexClass/describe/');
+      expect(result).toEqual(mockResponse);
     });
   });
 
   describe('create', () => {
     it('should create a new record', async () => {
       const mockResponse = {
-        data: {
-          id: '123',
-          success: true,
-          errors: []
-        }
+        id: '123',
+        success: true,
+        errors: []
       };
 
-      mockHttpClient.post.mockResolvedValue(mockResponse);
+      mockAuth.toolingRequest.mockResolvedValue(mockResponse);
 
       const data = { Name: 'TestClass', Body: 'public class TestClass {}' };
       const result = await client.create('ApexClass', data);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith('sobjects/ApexClass/', data);
-      expect(result).toEqual(mockResponse.data);
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('sobjects/ApexClass/', {
+        method: 'POST',
+        body: JSON.stringify(data),
+        headers: { 'Content-Type': 'application/json' }
+      });
+      expect(result).toEqual(mockResponse);
     });
   });
 
   describe('get', () => {
     it('should get a record by id', async () => {
-      const mockResponse = {
-        data: { Id: '123', Name: 'TestClass', Body: 'public class TestClass {}' }
-      };
+      const mockResponse = { Id: '123', Name: 'TestClass', Body: 'public class TestClass {}' };
 
-      mockHttpClient.get.mockResolvedValue(mockResponse);
+      mockAuth.toolingRequest.mockResolvedValue(mockResponse);
 
       const result = await client.get('ApexClass', '123');
 
-      expect(mockHttpClient.get).toHaveBeenCalledWith('sobjects/ApexClass/123', { params: {} });
-      expect(result).toEqual(mockResponse.data);
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('sobjects/ApexClass/123');
+      expect(result).toEqual(mockResponse);
     });
 
     it('should get a record with specific fields', async () => {
-      const mockResponse = {
-        data: { Id: '123', Name: 'TestClass' }
-      };
+      const mockResponse = { Id: '123', Name: 'TestClass' };
 
-      mockHttpClient.get.mockResolvedValue(mockResponse);
+      mockAuth.toolingRequest.mockResolvedValue(mockResponse);
 
       const result = await client.get('ApexClass', '123', ['Id', 'Name']);
 
-      expect(mockHttpClient.get).toHaveBeenCalledWith('sobjects/ApexClass/123', {
-        params: { fields: 'Id,Name' }
-      });
-      expect(result).toEqual(mockResponse.data);
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('sobjects/ApexClass/123?fields=Id%2CName');
+      expect(result).toEqual(mockResponse);
     });
   });
 
   describe('update', () => {
     it('should update a record', async () => {
-      mockHttpClient.patch.mockResolvedValue({ data: {} });
+      mockAuth.toolingRequest.mockResolvedValue({});
 
       const data = { Body: 'public class UpdatedTestClass {}' };
       await client.update('ApexClass', '123', data);
 
-      expect(mockHttpClient.patch).toHaveBeenCalledWith('sobjects/ApexClass/123', data);
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('sobjects/ApexClass/123', {
+        method: 'PATCH',
+        body: JSON.stringify(data),
+        headers: { 'Content-Type': 'application/json' }
+      });
     });
   });
 
   describe('delete', () => {
     it('should delete a record', async () => {
-      mockHttpClient.delete.mockResolvedValue({ data: {} });
+      mockAuth.toolingRequest.mockResolvedValue({});
 
       await client.delete('ApexClass', '123');
 
-      expect(mockHttpClient.delete).toHaveBeenCalledWith('sobjects/ApexClass/123');
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('sobjects/ApexClass/123', {
+        method: 'DELETE'
+      });
     });
   });
 
   describe('getApexClasses', () => {
     it('should get all apex classes', async () => {
       const mockResponse = {
-        data: {
-          records: [
-            { Id: '123', Name: 'TestClass1', Body: 'public class TestClass1 {}' },
-            { Id: '456', Name: 'TestClass2', Body: 'public class TestClass2 {}' }
-          ]
-        }
+        records: [
+          { Id: '123', Name: 'TestClass1', Body: 'public class TestClass1 {}' },
+          { Id: '456', Name: 'TestClass2', Body: 'public class TestClass2 {}' }
+        ]
       };
 
-      mockHttpClient.get.mockResolvedValue(mockResponse);
+      mockAuth.toolingRequest.mockResolvedValue(mockResponse);
 
       const result = await client.getApexClasses();
 
-      expect(mockHttpClient.get).toHaveBeenCalledWith('query/', {
-        params: { 
-          q: 'SELECT Id, Name, Body, NamespacePrefix, ApiVersion, Status, IsValid, BodyCrc, LengthWithoutComments, LastModifiedDate, CreatedDate FROM ApexClass ORDER BY Name'
-        }
-      });
-      expect(result).toEqual(mockResponse.data.records);
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('query/?q=SELECT+Id%2C+Name%2C+Body%2C+NamespacePrefix%2C+ApiVersion%2C+Status%2C+IsValid%2C+BodyCrc%2C+LengthWithoutComments%2C+LastModifiedDate%2C+CreatedDate+FROM+ApexClass+ORDER+BY+Name');
+      expect(result).toEqual(mockResponse.records);
     });
 
     it('should get apex classes with name filter', async () => {
       const mockResponse = {
-        data: {
-          records: [
-            { Id: '123', Name: 'TestClass', Body: 'public class TestClass {}' }
-          ]
-        }
+        records: [
+          { Id: '123', Name: 'TestClass', Body: 'public class TestClass {}' }
+        ]
       };
 
-      mockHttpClient.get.mockResolvedValue(mockResponse);
+      mockAuth.toolingRequest.mockResolvedValue(mockResponse);
 
       const result = await client.getApexClasses('Test');
 
-      expect(mockHttpClient.get).toHaveBeenCalledWith('query/', {
-        params: { 
-          q: "SELECT Id, Name, Body, NamespacePrefix, ApiVersion, Status, IsValid, BodyCrc, LengthWithoutComments, LastModifiedDate, CreatedDate FROM ApexClass WHERE Name LIKE '%Test%' ORDER BY Name"
-        }
-      });
-      expect(result).toEqual(mockResponse.data.records);
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('query/?q=SELECT+Id%2C+Name%2C+Body%2C+NamespacePrefix%2C+ApiVersion%2C+Status%2C+IsValid%2C+BodyCrc%2C+LengthWithoutComments%2C+LastModifiedDate%2C+CreatedDate+FROM+ApexClass+WHERE+Name+LIKE+%27%25Test%25%27+ORDER+BY+Name');
+      expect(result).toEqual(mockResponse.records);
     });
   });
 
   describe('getApexClass', () => {
     it('should get a specific apex class', async () => {
-      const mockResponse = {
-        data: { Id: '123', Name: 'TestClass', Body: 'public class TestClass {}' }
-      };
+      const mockResponse = { Id: '123', Name: 'TestClass', Body: 'public class TestClass {}' };
 
-      mockHttpClient.get.mockResolvedValue(mockResponse);
+      mockAuth.toolingRequest.mockResolvedValue(mockResponse);
 
       const result = await client.getApexClass('123');
 
-      expect(mockHttpClient.get).toHaveBeenCalledWith('sobjects/ApexClass/123', { params: {} });
-      expect(result).toEqual(mockResponse.data);
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('sobjects/ApexClass/123');
+      expect(result).toEqual(mockResponse);
     });
   });
 
   describe('createApexClass', () => {
     it('should create a new apex class', async () => {
       const mockResponse = {
-        data: {
-          id: '123',
-          success: true,
-          errors: []
-        }
+        id: '123',
+        success: true,
+        errors: []
       };
 
-      mockHttpClient.post.mockResolvedValue(mockResponse);
+      mockAuth.toolingRequest.mockResolvedValue(mockResponse);
 
       const result = await client.createApexClass('TestClass', 'public class TestClass {}');
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith('sobjects/ApexClass/', {
-        Name: 'TestClass',
-        Body: 'public class TestClass {}'
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('sobjects/ApexClass/', {
+        method: 'POST',
+        body: JSON.stringify({
+          Name: 'TestClass',
+          Body: 'public class TestClass {}'
+        }),
+        headers: { 'Content-Type': 'application/json' }
       });
-      expect(result).toEqual(mockResponse.data);
+      expect(result).toEqual(mockResponse);
     });
   });
 
   describe('updateApexClass', () => {
     it('should update an apex class', async () => {
-      mockHttpClient.patch.mockResolvedValue({ data: {} });
+      mockAuth.toolingRequest.mockResolvedValue({});
 
       await client.updateApexClass('123', 'public class UpdatedTestClass {}');
 
-      expect(mockHttpClient.patch).toHaveBeenCalledWith('sobjects/ApexClass/123', {
-        Body: 'public class UpdatedTestClass {}'
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('sobjects/ApexClass/123', {
+        method: 'PATCH',
+        body: JSON.stringify({ Body: 'public class UpdatedTestClass {}' }),
+        headers: { 'Content-Type': 'application/json' }
       });
     });
   });
 
   describe('deleteApexClass', () => {
     it('should delete an apex class', async () => {
-      mockHttpClient.delete.mockResolvedValue({ data: {} });
+      mockAuth.toolingRequest.mockResolvedValue({});
 
       await client.deleteApexClass('123');
 
-      expect(mockHttpClient.delete).toHaveBeenCalledWith('sobjects/ApexClass/123');
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('sobjects/ApexClass/123', {
+        method: 'DELETE'
+      });
     });
   });
 
   describe('getCodeCoverage', () => {
     it('should get code coverage for all classes', async () => {
       const mockResponse = {
-        data: {
-          records: [
-            {
-              ApexClassOrTriggerId: '123',
-              ApexClassOrTriggerName: 'TestClass',
-              NumLinesCovered: 10,
-              NumLinesUncovered: 5,
-              Coverage: { coveredLines: [1, 2, 3], uncoveredLines: [4, 5] }
-            }
-          ]
-        }
+        records: [
+          {
+            ApexClassOrTriggerId: '123',
+            ApexClassOrTriggerName: 'TestClass',
+            NumLinesCovered: 10,
+            NumLinesUncovered: 5,
+            Coverage: { coveredLines: [1, 2, 3], uncoveredLines: [4, 5] }
+          }
+        ]
       };
 
-      mockHttpClient.get.mockResolvedValue(mockResponse);
+      mockAuth.toolingRequest.mockResolvedValue(mockResponse);
 
       const result = await client.getCodeCoverage();
 
-      expect(mockHttpClient.get).toHaveBeenCalledWith('query/', {
-        params: { 
-          q: 'SELECT ApexClassOrTriggerId, ApexClassOrTrigger.Name, NumLinesCovered, NumLinesUncovered, Coverage FROM ApexCodeCoverageAggregate'
-        }
-      });
-      expect(result).toEqual(mockResponse.data.records);
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('query/?q=SELECT+ApexClassOrTriggerId%2C+ApexClassOrTrigger.Name%2C+NumLinesCovered%2C+NumLinesUncovered%2C+Coverage+FROM+ApexCodeCoverageAggregate');
+      expect(result).toEqual(mockResponse.records);
     });
 
     it('should get code coverage for specific class', async () => {
       const mockResponse = {
-        data: {
-          records: [
-            {
-              ApexClassOrTriggerId: '123',
-              ApexClassOrTriggerName: 'TestClass',
-              NumLinesCovered: 10,
-              NumLinesUncovered: 5,
-              Coverage: { coveredLines: [1, 2, 3], uncoveredLines: [4, 5] }
-            }
-          ]
-        }
+        records: [
+          {
+            ApexClassOrTriggerId: '123',
+            ApexClassOrTriggerName: 'TestClass',
+            NumLinesCovered: 10,
+            NumLinesUncovered: 5,
+            Coverage: { coveredLines: [1, 2, 3], uncoveredLines: [4, 5] }
+          }
+        ]
       };
 
-      mockHttpClient.get.mockResolvedValue(mockResponse);
+      mockAuth.toolingRequest.mockResolvedValue(mockResponse);
 
       const result = await client.getCodeCoverage('123');
 
-      expect(mockHttpClient.get).toHaveBeenCalledWith('query/', {
-        params: { 
-          q: "SELECT ApexClassOrTriggerId, ApexClassOrTrigger.Name, NumLinesCovered, NumLinesUncovered, Coverage FROM ApexCodeCoverageAggregate WHERE ApexClassOrTriggerId = '123'"
-        }
-      });
-      expect(result).toEqual(mockResponse.data.records);
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('query/?q=SELECT+ApexClassOrTriggerId%2C+ApexClassOrTrigger.Name%2C+NumLinesCovered%2C+NumLinesUncovered%2C+Coverage+FROM+ApexCodeCoverageAggregate+WHERE+ApexClassOrTriggerId+%3D+%27123%27');
+      expect(result).toEqual(mockResponse.records);
     });
   });
 
   describe('runTests', () => {
     it('should run tests', async () => {
-      const mockResponse = {
-        data: { AsyncApexJobId: 'job123' }
-      };
+      const mockResponse = { AsyncApexJobId: 'job123' };
 
-      mockHttpClient.post.mockResolvedValue(mockResponse);
+      mockAuth.toolingRequest.mockResolvedValue(mockResponse);
 
       const result = await client.runTests(['class123', 'class456']);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith('runTestsAsynchronous/', {
-        tests: [{ classId: 'class123' }, { classId: 'class456' }],
-        maxFailedTests: 1
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('runTestsAsynchronous/', {
+        method: 'POST',
+        body: JSON.stringify({
+          tests: [{ classId: 'class123' }, { classId: 'class456' }],
+          maxFailedTests: 1
+        }),
+        headers: { 'Content-Type': 'application/json' }
       });
-      expect(result).toEqual(mockResponse.data);
+      expect(result).toEqual(mockResponse);
     });
 
     it('should run tests without class ids', async () => {
-      const mockResponse = {
-        data: { AsyncApexJobId: 'job123' }
-      };
+      const mockResponse = { AsyncApexJobId: 'job123' };
 
-      mockHttpClient.post.mockResolvedValue(mockResponse);
+      mockAuth.toolingRequest.mockResolvedValue(mockResponse);
 
       const result = await client.runTests();
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith('runTestsAsynchronous/', {
-        tests: [],
-        maxFailedTests: 1
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('runTestsAsynchronous/', {
+        method: 'POST',
+        body: JSON.stringify({
+          tests: [],
+          maxFailedTests: 1
+        }),
+        headers: { 'Content-Type': 'application/json' }
       });
-      expect(result).toEqual(mockResponse.data);
+      expect(result).toEqual(mockResponse);
     });
   });
 
   describe('getTestResults', () => {
     it('should get test results', async () => {
       const mockResponse = {
-        data: {
-          records: [{
-            Id: 'job123',
-            Status: 'Completed',
-            JobItemsProcessed: 5,
-            TotalJobItems: 5,
-            NumberOfErrors: 0
-          }]
-        }
+        records: [{
+          Id: 'job123',
+          Status: 'Completed',
+          JobItemsProcessed: 5,
+          TotalJobItems: 5,
+          NumberOfErrors: 0
+        }]
       };
 
-      mockHttpClient.get.mockResolvedValue(mockResponse);
+      mockAuth.toolingRequest.mockResolvedValue(mockResponse);
 
       const result = await client.getTestResults('job123');
 
-      expect(mockHttpClient.get).toHaveBeenCalledWith('query/', {
-        params: { 
-          q: "SELECT Id, Status, JobItemsProcessed, TotalJobItems, NumberOfErrors FROM AsyncApexJob WHERE Id = 'job123'"
-        }
-      });
-      expect(result).toEqual(mockResponse.data.records[0]);
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('query/?q=SELECT+Id%2C+Status%2C+JobItemsProcessed%2C+TotalJobItems%2C+NumberOfErrors+FROM+AsyncApexJob+WHERE+Id+%3D+%27job123%27');
+      expect(result).toEqual(mockResponse.records[0]);
     });
   });
 
   describe('getOrgInfo', () => {
     it('should get organization info', async () => {
       const mockResponse = {
-        data: {
-          records: [{
-            Id: '00D123456789012',
-            Name: 'Test Org',
-            OrganizationType: 'Developer Edition',
-            InstanceName: 'CS123',
-            IsSandbox: false
-          }]
-        }
+        records: [{
+          Id: '00D123456789012',
+          Name: 'Test Org',
+          OrganizationType: 'Developer Edition',
+          InstanceName: 'CS123',
+          IsSandbox: false
+        }]
       };
 
-      mockedAxios.get.mockResolvedValue(mockResponse);
+      mockAuth.restRequest.mockResolvedValue(mockResponse);
 
       const result = await client.getOrgInfo();
 
-      expect(mockAuth.getAccessToken).toHaveBeenCalled();
-      expect(mockAuth.getInstanceUrl).toHaveBeenCalled();
-      expect(mockedAxios.get).toHaveBeenCalledWith(
-        'https://test.salesforce.com/services/data/v59.0/query',
-        {
-          params: {
-            q: 'SELECT Id, Name, OrganizationType, InstanceName, IsSandbox FROM Organization LIMIT 1'
-          },
-          headers: {
-            'Authorization': 'Bearer fake-token',
-            'Content-Type': 'application/json',
-            'Accept': 'application/json'
-          }
-        }
-      );
-      expect(result).toEqual(mockResponse.data.records[0]);
+      expect(mockAuth.restRequest).toHaveBeenCalledWith('query?q=SELECT+Id%2C+Name%2C+OrganizationType%2C+InstanceName%2C+IsSandbox+FROM+Organization+LIMIT+1');
+      expect(result).toEqual(mockResponse.records[0]);
     });
   });
 
   describe('getAsyncApexJobs', () => {
     it('should get all async apex jobs', async () => {
       const mockResponse = {
-        data: {
-          records: [{ Id: 'job123', Status: 'Completed' }]
-        }
+        records: [{ Id: 'job123', Status: 'Completed' }]
       };
 
-      mockHttpClient.get.mockResolvedValue(mockResponse);
+      mockAuth.toolingRequest.mockResolvedValue(mockResponse);
 
       const result = await client.getAsyncApexJobs();
 
-      expect(mockHttpClient.get).toHaveBeenCalledWith('query/', {
-        params: { 
-          q: 'SELECT Id, Status, JobType, MethodName, JobItemsProcessed, TotalJobItems, NumberOfErrors, CompletedDate, CreatedDate, CreatedBy.Name FROM AsyncApexJob ORDER BY CreatedDate DESC LIMIT 100'
-        }
-      });
-      expect(result).toEqual(mockResponse.data.records);
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('query/?q=SELECT+Id%2C+Status%2C+JobType%2C+MethodName%2C+JobItemsProcessed%2C+TotalJobItems%2C+NumberOfErrors%2C+CompletedDate%2C+CreatedDate%2C+CreatedBy.Name+FROM+AsyncApexJob+ORDER+BY+CreatedDate+DESC+LIMIT+100');
+      expect(result).toEqual(mockResponse.records);
     });
 
     it('should get async apex jobs with status filter', async () => {
       const mockResponse = {
-        data: {
-          records: [{ Id: 'job123', Status: 'Completed' }]
-        }
+        records: [{ Id: 'job123', Status: 'Completed' }]
       };
 
-      mockHttpClient.get.mockResolvedValue(mockResponse);
+      mockAuth.toolingRequest.mockResolvedValue(mockResponse);
 
       const result = await client.getAsyncApexJobs('Completed', 50);
 
-      expect(mockHttpClient.get).toHaveBeenCalledWith('query/', {
-        params: { 
-          q: "SELECT Id, Status, JobType, MethodName, JobItemsProcessed, TotalJobItems, NumberOfErrors, CompletedDate, CreatedDate, CreatedBy.Name FROM AsyncApexJob WHERE Status = 'Completed' ORDER BY CreatedDate DESC LIMIT 50"
-        }
-      });
-      expect(result).toEqual(mockResponse.data.records);
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('query/?q=SELECT+Id%2C+Status%2C+JobType%2C+MethodName%2C+JobItemsProcessed%2C+TotalJobItems%2C+NumberOfErrors%2C+CompletedDate%2C+CreatedDate%2C+CreatedBy.Name+FROM+AsyncApexJob+WHERE+Status+%3D+%27Completed%27+ORDER+BY+CreatedDate+DESC+LIMIT+50');
+      expect(result).toEqual(mockResponse.records);
     });
   });
 
   describe('getAsyncApexJob', () => {
     it('should get a specific async apex job', async () => {
       const mockResponse = {
-        data: {
-          records: [{ Id: 'job123', Status: 'Completed', ExtendedStatus: null }]
-        }
+        records: [{ Id: 'job123', Status: 'Completed', ExtendedStatus: null }]
       };
 
-      mockHttpClient.get.mockResolvedValue(mockResponse);
+      mockAuth.toolingRequest.mockResolvedValue(mockResponse);
 
       const result = await client.getAsyncApexJob('job123');
 
-      expect(mockHttpClient.get).toHaveBeenCalledWith('query/', {
-        params: { 
-          q: "SELECT Id, Status, JobType, MethodName, JobItemsProcessed, TotalJobItems, NumberOfErrors, CompletedDate, CreatedDate, CreatedBy.Name, ExtendedStatus FROM AsyncApexJob WHERE Id = 'job123'"
-        }
-      });
-      expect(result).toEqual(mockResponse.data.records[0]);
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('query/?q=SELECT+Id%2C+Status%2C+JobType%2C+MethodName%2C+JobItemsProcessed%2C+TotalJobItems%2C+NumberOfErrors%2C+CompletedDate%2C+CreatedDate%2C+CreatedBy.Name%2C+ExtendedStatus+FROM+AsyncApexJob+WHERE+Id+%3D+%27job123%27');
+      expect(result).toEqual(mockResponse.records[0]);
     });
   });
 
   describe('searchAsyncApexJobs', () => {
     it('should search async apex jobs with all filters', async () => {
       const mockResponse = {
-        data: {
-          records: [{ Id: 'job123', Status: 'Completed', JobType: 'BatchApex' }]
-        }
+        records: [{ Id: 'job123', Status: 'Completed', JobType: 'BatchApex' }]
       };
 
-      mockHttpClient.get.mockResolvedValue(mockResponse);
+      mockAuth.toolingRequest.mockResolvedValue(mockResponse);
 
       const searchParams = {
         status: 'Completed',
@@ -544,31 +453,21 @@ describe('SalesforceToolingClient', () => {
 
       const result = await client.searchAsyncApexJobs(searchParams);
 
-      expect(mockHttpClient.get).toHaveBeenCalledWith('query/', {
-        params: { 
-          q: "SELECT Id, Status, JobType, MethodName, JobItemsProcessed, TotalJobItems, NumberOfErrors, CompletedDate, CreatedDate, CreatedBy.Name, ApexClass.Name FROM AsyncApexJob WHERE Id != NULL AND Status = 'Completed' AND JobType = 'BatchApex' AND ApexClass.Name LIKE '%TestBatch%' AND CreatedDate >= 2023-01-01T00:00:00Z AND CreatedDate <= 2023-12-31T23:59:59Z ORDER BY CreatedDate DESC LIMIT 50"
-        }
-      });
-      expect(result).toEqual(mockResponse.data.records);
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('query/?q=SELECT+Id%2C+Status%2C+JobType%2C+MethodName%2C+JobItemsProcessed%2C+TotalJobItems%2C+NumberOfErrors%2C+CompletedDate%2C+CreatedDate%2C+CreatedBy.Name%2C+ApexClass.Name+FROM+AsyncApexJob+WHERE+Id+%21%3D+NULL+AND+Status+%3D+%27Completed%27+AND+JobType+%3D+%27BatchApex%27+AND+ApexClass.Name+LIKE+%27%25TestBatch%25%27+AND+CreatedDate+%3E%3D+2023-01-01T00%3A00%3A00Z+AND+CreatedDate+%3C%3D+2023-12-31T23%3A59%3A59Z+ORDER+BY+CreatedDate+DESC+LIMIT+50');
+      expect(result).toEqual(mockResponse.records);
     });
 
     it('should search async apex jobs without filters', async () => {
       const mockResponse = {
-        data: {
-          records: [{ Id: 'job123', Status: 'Completed' }]
-        }
+        records: [{ Id: 'job123', Status: 'Completed' }]
       };
 
-      mockHttpClient.get.mockResolvedValue(mockResponse);
+      mockAuth.toolingRequest.mockResolvedValue(mockResponse);
 
       const result = await client.searchAsyncApexJobs({});
 
-      expect(mockHttpClient.get).toHaveBeenCalledWith('query/', {
-        params: { 
-          q: 'SELECT Id, Status, JobType, MethodName, JobItemsProcessed, TotalJobItems, NumberOfErrors, CompletedDate, CreatedDate, CreatedBy.Name, ApexClass.Name FROM AsyncApexJob WHERE Id != NULL ORDER BY CreatedDate DESC LIMIT 100'
-        }
-      });
-      expect(result).toEqual(mockResponse.data.records);
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('query/?q=SELECT+Id%2C+Status%2C+JobType%2C+MethodName%2C+JobItemsProcessed%2C+TotalJobItems%2C+NumberOfErrors%2C+CompletedDate%2C+CreatedDate%2C+CreatedBy.Name%2C+ApexClass.Name+FROM+AsyncApexJob+WHERE+Id+%21%3D+NULL+ORDER+BY+CreatedDate+DESC+LIMIT+100');
+      expect(result).toEqual(mockResponse.records);
     });
   });
 });

--- a/src/client/__tests__/tooling-client.test.ts
+++ b/src/client/__tests__/tooling-client.test.ts
@@ -23,8 +23,6 @@ describe('SalesforceToolingClient', () => {
     };
 
     mockAuth = {
-      getAccessToken: jest.fn().mockResolvedValue('fake-token'),
-      getInstanceUrl: jest.fn().mockReturnValue('https://test.salesforce.com'),
       toolingRequest: jest.fn().mockResolvedValue({}),
       restRequest: jest.fn().mockResolvedValue({})
     } as any;
@@ -60,7 +58,7 @@ describe('SalesforceToolingClient', () => {
 
       const result = await client.query('SELECT Id, Name FROM ApexClass');
 
-      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('query/?q=SELECT+Id%2C+Name+FROM+ApexClass');
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('/query/?q=SELECT+Id%2C+Name+FROM+ApexClass');
       expect(result).toEqual(mockResponse);
     });
   });
@@ -93,7 +91,7 @@ describe('SalesforceToolingClient', () => {
 
       const result = await client.describe('ApexClass');
 
-      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('sobjects/ApexClass/describe/');
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('/sobjects/ApexClass/describe/');
       expect(result).toEqual(mockResponse);
     });
   });
@@ -111,7 +109,7 @@ describe('SalesforceToolingClient', () => {
       const data = { Name: 'TestClass', Body: 'public class TestClass {}' };
       const result = await client.create('ApexClass', data);
 
-      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('sobjects/ApexClass/', {
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('/sobjects/ApexClass/', {
         method: 'POST',
         body: JSON.stringify(data),
         headers: { 'Content-Type': 'application/json' }
@@ -128,7 +126,7 @@ describe('SalesforceToolingClient', () => {
 
       const result = await client.get('ApexClass', '123');
 
-      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('sobjects/ApexClass/123');
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('/sobjects/ApexClass/123');
       expect(result).toEqual(mockResponse);
     });
 
@@ -139,7 +137,7 @@ describe('SalesforceToolingClient', () => {
 
       const result = await client.get('ApexClass', '123', ['Id', 'Name']);
 
-      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('sobjects/ApexClass/123?fields=Id%2CName');
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('/sobjects/ApexClass/123?fields=Id%2CName');
       expect(result).toEqual(mockResponse);
     });
   });
@@ -151,7 +149,7 @@ describe('SalesforceToolingClient', () => {
       const data = { Body: 'public class UpdatedTestClass {}' };
       await client.update('ApexClass', '123', data);
 
-      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('sobjects/ApexClass/123', {
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('/sobjects/ApexClass/123', {
         method: 'PATCH',
         body: JSON.stringify(data),
         headers: { 'Content-Type': 'application/json' }
@@ -165,7 +163,7 @@ describe('SalesforceToolingClient', () => {
 
       await client.delete('ApexClass', '123');
 
-      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('sobjects/ApexClass/123', {
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('/sobjects/ApexClass/123', {
         method: 'DELETE'
       });
     });
@@ -184,7 +182,7 @@ describe('SalesforceToolingClient', () => {
 
       const result = await client.getApexClasses();
 
-      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('query/?q=SELECT+Id%2C+Name%2C+Body%2C+NamespacePrefix%2C+ApiVersion%2C+Status%2C+IsValid%2C+BodyCrc%2C+LengthWithoutComments%2C+LastModifiedDate%2C+CreatedDate+FROM+ApexClass+ORDER+BY+Name');
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('/query/?q=SELECT+Id%2C+Name%2C+Body%2C+NamespacePrefix%2C+ApiVersion%2C+Status%2C+IsValid%2C+BodyCrc%2C+LengthWithoutComments%2C+LastModifiedDate%2C+CreatedDate+FROM+ApexClass+ORDER+BY+Name');
       expect(result).toEqual(mockResponse.records);
     });
 
@@ -199,7 +197,7 @@ describe('SalesforceToolingClient', () => {
 
       const result = await client.getApexClasses('Test');
 
-      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('query/?q=SELECT+Id%2C+Name%2C+Body%2C+NamespacePrefix%2C+ApiVersion%2C+Status%2C+IsValid%2C+BodyCrc%2C+LengthWithoutComments%2C+LastModifiedDate%2C+CreatedDate+FROM+ApexClass+WHERE+Name+LIKE+%27%25Test%25%27+ORDER+BY+Name');
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('/query/?q=SELECT+Id%2C+Name%2C+Body%2C+NamespacePrefix%2C+ApiVersion%2C+Status%2C+IsValid%2C+BodyCrc%2C+LengthWithoutComments%2C+LastModifiedDate%2C+CreatedDate+FROM+ApexClass+WHERE+Name+LIKE+%27%25Test%25%27+ORDER+BY+Name');
       expect(result).toEqual(mockResponse.records);
     });
   });
@@ -212,7 +210,7 @@ describe('SalesforceToolingClient', () => {
 
       const result = await client.getApexClass('123');
 
-      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('sobjects/ApexClass/123');
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('/sobjects/ApexClass/123');
       expect(result).toEqual(mockResponse);
     });
   });
@@ -229,7 +227,7 @@ describe('SalesforceToolingClient', () => {
 
       const result = await client.createApexClass('TestClass', 'public class TestClass {}');
 
-      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('sobjects/ApexClass/', {
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('/sobjects/ApexClass/', {
         method: 'POST',
         body: JSON.stringify({
           Name: 'TestClass',
@@ -247,7 +245,7 @@ describe('SalesforceToolingClient', () => {
 
       await client.updateApexClass('123', 'public class UpdatedTestClass {}');
 
-      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('sobjects/ApexClass/123', {
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('/sobjects/ApexClass/123', {
         method: 'PATCH',
         body: JSON.stringify({ Body: 'public class UpdatedTestClass {}' }),
         headers: { 'Content-Type': 'application/json' }
@@ -261,7 +259,7 @@ describe('SalesforceToolingClient', () => {
 
       await client.deleteApexClass('123');
 
-      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('sobjects/ApexClass/123', {
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('/sobjects/ApexClass/123', {
         method: 'DELETE'
       });
     });
@@ -285,7 +283,7 @@ describe('SalesforceToolingClient', () => {
 
       const result = await client.getCodeCoverage();
 
-      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('query/?q=SELECT+ApexClassOrTriggerId%2C+ApexClassOrTrigger.Name%2C+NumLinesCovered%2C+NumLinesUncovered%2C+Coverage+FROM+ApexCodeCoverageAggregate');
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('/query/?q=SELECT+ApexClassOrTriggerId%2C+ApexClassOrTrigger.Name%2C+NumLinesCovered%2C+NumLinesUncovered%2C+Coverage+FROM+ApexCodeCoverageAggregate');
       expect(result).toEqual(mockResponse.records);
     });
 
@@ -306,7 +304,7 @@ describe('SalesforceToolingClient', () => {
 
       const result = await client.getCodeCoverage('123');
 
-      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('query/?q=SELECT+ApexClassOrTriggerId%2C+ApexClassOrTrigger.Name%2C+NumLinesCovered%2C+NumLinesUncovered%2C+Coverage+FROM+ApexCodeCoverageAggregate+WHERE+ApexClassOrTriggerId+%3D+%27123%27');
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('/query/?q=SELECT+ApexClassOrTriggerId%2C+ApexClassOrTrigger.Name%2C+NumLinesCovered%2C+NumLinesUncovered%2C+Coverage+FROM+ApexCodeCoverageAggregate+WHERE+ApexClassOrTriggerId+%3D+%27123%27');
       expect(result).toEqual(mockResponse.records);
     });
   });
@@ -365,7 +363,7 @@ describe('SalesforceToolingClient', () => {
 
       const result = await client.getTestResults('job123');
 
-      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('query/?q=SELECT+Id%2C+Status%2C+JobItemsProcessed%2C+TotalJobItems%2C+NumberOfErrors+FROM+AsyncApexJob+WHERE+Id+%3D+%27job123%27');
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('/query/?q=SELECT+Id%2C+Status%2C+JobItemsProcessed%2C+TotalJobItems%2C+NumberOfErrors+FROM+AsyncApexJob+WHERE+Id+%3D+%27job123%27');
       expect(result).toEqual(mockResponse.records[0]);
     });
   });
@@ -380,7 +378,7 @@ describe('SalesforceToolingClient', () => {
 
       const result = await client.getAsyncApexJobs();
 
-      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('query/?q=SELECT+Id%2C+Status%2C+JobType%2C+MethodName%2C+JobItemsProcessed%2C+TotalJobItems%2C+NumberOfErrors%2C+CompletedDate%2C+CreatedDate%2C+CreatedBy.Name+FROM+AsyncApexJob+ORDER+BY+CreatedDate+DESC+LIMIT+100');
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('/query/?q=SELECT+Id%2C+Status%2C+JobType%2C+MethodName%2C+JobItemsProcessed%2C+TotalJobItems%2C+NumberOfErrors%2C+CompletedDate%2C+CreatedDate%2C+CreatedBy.Name+FROM+AsyncApexJob+ORDER+BY+CreatedDate+DESC+LIMIT+100');
       expect(result).toEqual(mockResponse.records);
     });
 
@@ -393,7 +391,7 @@ describe('SalesforceToolingClient', () => {
 
       const result = await client.getAsyncApexJobs('Completed', 50);
 
-      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('query/?q=SELECT+Id%2C+Status%2C+JobType%2C+MethodName%2C+JobItemsProcessed%2C+TotalJobItems%2C+NumberOfErrors%2C+CompletedDate%2C+CreatedDate%2C+CreatedBy.Name+FROM+AsyncApexJob+WHERE+Status+%3D+%27Completed%27+ORDER+BY+CreatedDate+DESC+LIMIT+50');
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('/query/?q=SELECT+Id%2C+Status%2C+JobType%2C+MethodName%2C+JobItemsProcessed%2C+TotalJobItems%2C+NumberOfErrors%2C+CompletedDate%2C+CreatedDate%2C+CreatedBy.Name+FROM+AsyncApexJob+WHERE+Status+%3D+%27Completed%27+ORDER+BY+CreatedDate+DESC+LIMIT+50');
       expect(result).toEqual(mockResponse.records);
     });
   });
@@ -408,7 +406,7 @@ describe('SalesforceToolingClient', () => {
 
       const result = await client.getAsyncApexJob('job123');
 
-      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('query/?q=SELECT+Id%2C+Status%2C+JobType%2C+MethodName%2C+JobItemsProcessed%2C+TotalJobItems%2C+NumberOfErrors%2C+CompletedDate%2C+CreatedDate%2C+CreatedBy.Name%2C+ExtendedStatus+FROM+AsyncApexJob+WHERE+Id+%3D+%27job123%27');
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('/query/?q=SELECT+Id%2C+Status%2C+JobType%2C+MethodName%2C+JobItemsProcessed%2C+TotalJobItems%2C+NumberOfErrors%2C+CompletedDate%2C+CreatedDate%2C+CreatedBy.Name%2C+ExtendedStatus+FROM+AsyncApexJob+WHERE+Id+%3D+%27job123%27');
       expect(result).toEqual(mockResponse.records[0]);
     });
   });
@@ -432,7 +430,7 @@ describe('SalesforceToolingClient', () => {
 
       const result = await client.searchAsyncApexJobs(searchParams);
 
-      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('query/?q=SELECT+Id%2C+Status%2C+JobType%2C+MethodName%2C+JobItemsProcessed%2C+TotalJobItems%2C+NumberOfErrors%2C+CompletedDate%2C+CreatedDate%2C+CreatedBy.Name%2C+ApexClass.Name+FROM+AsyncApexJob+WHERE+Id+%21%3D+NULL+AND+Status+%3D+%27Completed%27+AND+JobType+%3D+%27BatchApex%27+AND+ApexClass.Name+LIKE+%27%25TestBatch%25%27+AND+CreatedDate+%3E%3D+2023-01-01T00%3A00%3A00Z+AND+CreatedDate+%3C%3D+2023-12-31T23%3A59%3A59Z+ORDER+BY+CreatedDate+DESC+LIMIT+50');
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('/query/?q=SELECT+Id%2C+Status%2C+JobType%2C+MethodName%2C+JobItemsProcessed%2C+TotalJobItems%2C+NumberOfErrors%2C+CompletedDate%2C+CreatedDate%2C+CreatedBy.Name%2C+ApexClass.Name+FROM+AsyncApexJob+WHERE+Id+%21%3D+NULL+AND+Status+%3D+%27Completed%27+AND+JobType+%3D+%27BatchApex%27+AND+ApexClass.Name+LIKE+%27%25TestBatch%25%27+AND+CreatedDate+%3E%3D+2023-01-01T00%3A00%3A00Z+AND+CreatedDate+%3C%3D+2023-12-31T23%3A59%3A59Z+ORDER+BY+CreatedDate+DESC+LIMIT+50');
       expect(result).toEqual(mockResponse.records);
     });
 
@@ -445,7 +443,7 @@ describe('SalesforceToolingClient', () => {
 
       const result = await client.searchAsyncApexJobs({});
 
-      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('query/?q=SELECT+Id%2C+Status%2C+JobType%2C+MethodName%2C+JobItemsProcessed%2C+TotalJobItems%2C+NumberOfErrors%2C+CompletedDate%2C+CreatedDate%2C+CreatedBy.Name%2C+ApexClass.Name+FROM+AsyncApexJob+WHERE+Id+%21%3D+NULL+ORDER+BY+CreatedDate+DESC+LIMIT+100');
+      expect(mockAuth.toolingRequest).toHaveBeenCalledWith('/query/?q=SELECT+Id%2C+Status%2C+JobType%2C+MethodName%2C+JobItemsProcessed%2C+TotalJobItems%2C+NumberOfErrors%2C+CompletedDate%2C+CreatedDate%2C+CreatedBy.Name%2C+ApexClass.Name+FROM+AsyncApexJob+WHERE+Id+%21%3D+NULL+ORDER+BY+CreatedDate+DESC+LIMIT+100');
       expect(result).toEqual(mockResponse.records);
     });
   });

--- a/src/client/rest-client.ts
+++ b/src/client/rest-client.ts
@@ -30,27 +30,26 @@ export class SalesforceRestClient {
       options.body = JSON.stringify(body);
       options.headers = { 'Content-Type': 'application/json' };
     }
-
     return await this.auth.restRequest(url, options);
   }
 
   // Specific REST API methods
   async getLimits(): Promise<any> {
-    return this.callApi('limits');
+    return this.callApi('/limits');
   }
 
   async getSObjects(): Promise<any> {
-    return this.callApi('sobjects');
+    return this.callApi('/sobjects');
   }
 
   async describeSObject(sobjectType: string): Promise<any> {
-    return this.callApi(`sobjects/${sobjectType}/describe`);
+    return this.callApi(`/sobjects/${sobjectType}/describe`);
   }
 
   async query(soql: string): Promise<any> {
     // Use standard REST API for all queries
     // Note: Tooling API objects should be queried via SalesforceToolingClient
-    return this.callApi('query', 'GET', null, { q: soql });
+    return this.callApi('/query', 'GET', null, { q: soql });
   }
 
   async queryMore(nextRecordsUrl: string): Promise<any> {
@@ -59,33 +58,20 @@ export class SalesforceRestClient {
   }
 
   async createRecord(sobjectType: string, data: any): Promise<any> {
-    return this.callApi(`sobjects/${sobjectType}`, 'POST', data);
+    return this.callApi(`/sobjects/${sobjectType}`, 'POST', data);
   }
 
   async getRecord(sobjectType: string, id: string, fields?: string[]): Promise<any> {
     const params = fields ? { fields: fields.join(',') } : {};
-    return this.callApi(`sobjects/${sobjectType}/${id}`, 'GET', null, params);
+    return this.callApi(`/sobjects/${sobjectType}/${id}`, 'GET', null, params);
   }
 
   async updateRecord(sobjectType: string, id: string, data: any): Promise<void> {
-    await this.callApi(`sobjects/${sobjectType}/${id}`, 'PATCH', data);
+    await this.callApi(`/sobjects/${sobjectType}/${id}`, 'PATCH', data);
   }
 
   async deleteRecord(sobjectType: string, id: string): Promise<void> {
-    await this.callApi(`sobjects/${sobjectType}/${id}`, 'DELETE');
+    await this.callApi(`/sobjects/${sobjectType}/${id}`, 'DELETE');
   }
 
-  // Get authentication info for direct use
-  async getAuth(): Promise<{ token: string; instanceUrl: string; apiVersion: string }> {
-    const token = await this.auth.getAccessToken();
-    const instanceUrl = this.auth.getInstanceUrl();
-    const apiVersion = '59.0';
-
-    return { token, instanceUrl, apiVersion };
-  }
-
-  // Get Connection for advanced usage
-  async getConnection() {
-    return await this.auth.getConnection();
-  }
 }

--- a/src/client/rest-client.ts
+++ b/src/client/rest-client.ts
@@ -1,73 +1,37 @@
-import axios, { AxiosInstance } from 'axios';
 import { SalesforceAuth } from '../auth/salesforce-auth.js';
 import { SalesforceConfig } from '../types/index.js';
 
 export class SalesforceRestClient {
   private auth: SalesforceAuth;
-  private httpClient: AxiosInstance;
 
   constructor(config: SalesforceConfig, sharedAuth?: SalesforceAuth) {
     this.auth = sharedAuth || new SalesforceAuth(config);
-
-    this.httpClient = axios.create({
-      timeout: 30000,
-      headers: {
-        'Content-Type': 'application/json',
-        Accept: 'application/json',
-      },
-    });
-
-    this.setupInterceptors();
-  }
-
-  private setupInterceptors(): void {
-    this.httpClient.interceptors.request.use(async (config) => {
-      const token = await this.auth.getAccessToken();
-      const instanceUrl = this.auth.getInstanceUrl();
-
-      config.headers.Authorization = `Bearer ${token}`;
-
-      if (!config.url?.startsWith('http')) {
-        config.url = `${instanceUrl}/services/data/v59.0/${config.url}`;
-      }
-
-      return config;
-    });
-
-    this.httpClient.interceptors.response.use(
-      (response) => response,
-      (error) => {
-        if (error.response?.status === 401) {
-          console.error(
-            'Authentication failed. Please check your credentials.'
-          );
-        }
-        if (error.response?.status === 400) {
-          console.error(
-            error.response.data?.message ||
-              'Bad Request. Please check your request parameters.'
-          );
-        }
-
-        return Promise.reject(error);
-      }
-    );
   }
 
   // Generic REST API call
   async callApi(endpoint: string, method: 'GET' | 'POST' | 'PATCH' | 'DELETE' = 'GET', body?: any, params?: any): Promise<any> {
-    const config: any = {
-      method,
-      url: endpoint,
-      params
-    };
+    let url = endpoint;
 
-    if (body && (method === 'POST' || method === 'PATCH')) {
-      config.data = body;
+    // Add query parameters to URL if provided
+    if (params) {
+      const searchParams = new URLSearchParams();
+      Object.keys(params).forEach(key => {
+        if (params[key] !== undefined && params[key] !== null) {
+          searchParams.append(key, params[key].toString());
+        }
+      });
+      if (searchParams.toString()) {
+        url += (url.includes('?') ? '&' : '?') + searchParams.toString();
+      }
     }
 
-    const response = await this.httpClient(config);
-    return response.data;
+    const options: any = { method };
+    if (body && (method === 'POST' || method === 'PATCH')) {
+      options.body = JSON.stringify(body);
+      options.headers = { 'Content-Type': 'application/json' };
+    }
+
+    return await this.auth.restRequest(url, options);
   }
 
   // Specific REST API methods
@@ -90,8 +54,8 @@ export class SalesforceRestClient {
   }
 
   async queryMore(nextRecordsUrl: string): Promise<any> {
-    const response = await this.httpClient.get(nextRecordsUrl);
-    return response.data;
+    // nextRecordsUrl is already a full URL, use it directly
+    return await this.auth.restRequest(nextRecordsUrl);
   }
 
   async createRecord(sobjectType: string, data: any): Promise<any> {
@@ -116,7 +80,12 @@ export class SalesforceRestClient {
     const token = await this.auth.getAccessToken();
     const instanceUrl = this.auth.getInstanceUrl();
     const apiVersion = '59.0';
-    
+
     return { token, instanceUrl, apiVersion };
+  }
+
+  // Get Connection for advanced usage
+  async getConnection() {
+    return await this.auth.getConnection();
   }
 }

--- a/src/client/tooling-client.ts
+++ b/src/client/tooling-client.ts
@@ -244,14 +244,6 @@ export class SalesforceToolingClient {
     return result.records[0];
   }
 
-  // Organization info (uses regular SOQL API, not Tooling API)
-  async getOrgInfo(): Promise<any> {
-    const soql = 'SELECT Id, Name, OrganizationType, InstanceName, IsSandbox FROM Organization LIMIT 1';
-    const url = `query?${new URLSearchParams({ q: soql }).toString()}`;
-    const response = await this.auth.restRequest(url);
-    return response.records[0];
-  }
-
   // AsyncApexJob methods
   async getAsyncApexJobs(statusFilter?: string, limit: number = 100): Promise<any[]> {
     let soql = 'SELECT Id, Status, JobType, MethodName, JobItemsProcessed, TotalJobItems, NumberOfErrors, CompletedDate, CreatedDate, CreatedBy.Name FROM AsyncApexJob';

--- a/src/client/tooling-client.ts
+++ b/src/client/tooling-client.ts
@@ -17,7 +17,7 @@ export class SalesforceToolingClient {
   }
 
   async query<T = any>(soql: string): Promise<ToolingApiResponse<T>> {
-    const url = `query/?${new URLSearchParams({ q: soql }).toString()}`;
+    const url = `/query/?${new URLSearchParams({ q: soql }).toString()}`;
     return await this.auth.toolingRequest(url);
   }
 
@@ -29,14 +29,14 @@ export class SalesforceToolingClient {
   }
 
   async describe(sobjectType: string): Promise<any> {
-    return await this.auth.toolingRequest(`sobjects/${sobjectType}/describe/`);
+    return await this.auth.toolingRequest(`/sobjects/${sobjectType}/describe/`);
   }
 
   async create(
     sobjectType: string,
     data: any
   ): Promise<{ id: string; success: boolean; errors: any[] }> {
-    return await this.auth.toolingRequest(`sobjects/${sobjectType}/`, {
+    return await this.auth.toolingRequest(`/sobjects/${sobjectType}/`, {
       method: 'POST',
       body: JSON.stringify(data),
       headers: { 'Content-Type': 'application/json' }
@@ -44,7 +44,7 @@ export class SalesforceToolingClient {
   }
 
   async get(sobjectType: string, id: string, fields?: string[]): Promise<any> {
-    let url = `sobjects/${sobjectType}/${id}`;
+    let url = `/sobjects/${sobjectType}/${id}`;
     if (fields) {
       url += `?${new URLSearchParams({ fields: fields.join(',') }).toString()}`;
     }
@@ -52,7 +52,7 @@ export class SalesforceToolingClient {
   }
 
   async update(sobjectType: string, id: string, data: any): Promise<void> {
-    await this.auth.toolingRequest(`sobjects/${sobjectType}/${id}`, {
+    await this.auth.toolingRequest(`/sobjects/${sobjectType}/${id}`, {
       method: 'PATCH',
       body: JSON.stringify(data),
       headers: { 'Content-Type': 'application/json' }
@@ -60,7 +60,7 @@ export class SalesforceToolingClient {
   }
 
   async delete(sobjectType: string, id: string): Promise<void> {
-    await this.auth.toolingRequest(`sobjects/${sobjectType}/${id}`, {
+    await this.auth.toolingRequest(`/sobjects/${sobjectType}/${id}`, {
       method: 'DELETE'
     });
   }

--- a/src/client/tooling-client.ts
+++ b/src/client/tooling-client.ts
@@ -1,4 +1,3 @@
-import axios, { AxiosInstance } from 'axios';
 import { SalesforceAuth } from '../auth/salesforce-auth.js';
 import {
   SalesforceConfig,
@@ -12,103 +11,58 @@ import {
 
 export class SalesforceToolingClient {
   private auth: SalesforceAuth;
-  private httpClient: AxiosInstance;
 
   constructor(config: SalesforceConfig, sharedAuth?: SalesforceAuth) {
     this.auth = sharedAuth || new SalesforceAuth(config);
-
-    this.httpClient = axios.create({
-      timeout: 30000,
-      headers: {
-        'Content-Type': 'application/json',
-        Accept: 'application/json',
-      },
-    });
-
-    this.setupInterceptors();
-  }
-
-  private setupInterceptors(): void {
-    this.httpClient.interceptors.request.use(async (config) => {
-      const token = await this.auth.getAccessToken();
-      const instanceUrl = this.auth.getInstanceUrl();
-
-      config.headers.Authorization = `Bearer ${token}`;
-
-      if (!config.url?.startsWith('http')) {
-        config.url = `${instanceUrl}/services/data/v59.0/tooling/${config.url}`;
-      }
-
-      return config;
-    });
-
-    this.httpClient.interceptors.response.use(
-      (response) => response,
-      (error) => {
-        if (error.response?.status === 401) {
-          console.error(
-            'Authentication failed. Please check your credentials.'
-          );
-        }
-        if (error.response?.status === 400) {
-          console.error(
-            error.response.data?.message ||
-              'Bad Request. Please check your request parameters.'
-          );
-        }
-
-        return Promise.reject(error);
-      }
-    );
   }
 
   async query<T = any>(soql: string): Promise<ToolingApiResponse<T>> {
-    const response = await this.httpClient.get('query/', {
-      params: { q: soql },
-    });
-    return response.data;
+    const url = `query/?${new URLSearchParams({ q: soql }).toString()}`;
+    return await this.auth.toolingRequest(url);
   }
 
   async queryMore<T = any>(
     nextRecordsUrl: string
   ): Promise<ToolingApiResponse<T>> {
-    const response = await this.httpClient.get(nextRecordsUrl);
-    return response.data;
+    // nextRecordsUrl is already a full URL, use it directly
+    return await this.auth.toolingRequest(nextRecordsUrl);
   }
 
   async describe(sobjectType: string): Promise<any> {
-    const response = await this.httpClient.get(
-      `sobjects/${sobjectType}/describe/`
-    );
-    return response.data;
+    return await this.auth.toolingRequest(`sobjects/${sobjectType}/describe/`);
   }
 
   async create(
     sobjectType: string,
     data: any
   ): Promise<{ id: string; success: boolean; errors: any[] }> {
-    const response = await this.httpClient.post(
-      `sobjects/${sobjectType}/`,
-      data
-    );
-    return response.data;
+    return await this.auth.toolingRequest(`sobjects/${sobjectType}/`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+      headers: { 'Content-Type': 'application/json' }
+    });
   }
 
   async get(sobjectType: string, id: string, fields?: string[]): Promise<any> {
-    const params = fields ? { fields: fields.join(',') } : {};
-    const response = await this.httpClient.get(
-      `sobjects/${sobjectType}/${id}`,
-      { params }
-    );
-    return response.data;
+    let url = `sobjects/${sobjectType}/${id}`;
+    if (fields) {
+      url += `?${new URLSearchParams({ fields: fields.join(',') }).toString()}`;
+    }
+    return await this.auth.toolingRequest(url);
   }
 
   async update(sobjectType: string, id: string, data: any): Promise<void> {
-    await this.httpClient.patch(`sobjects/${sobjectType}/${id}`, data);
+    await this.auth.toolingRequest(`sobjects/${sobjectType}/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+      headers: { 'Content-Type': 'application/json' }
+    });
   }
 
   async delete(sobjectType: string, id: string): Promise<void> {
-    await this.httpClient.delete(`sobjects/${sobjectType}/${id}`);
+    await this.auth.toolingRequest(`sobjects/${sobjectType}/${id}`, {
+      method: 'DELETE'
+    });
   }
 
   // Apex Class specific methods
@@ -267,10 +221,7 @@ export class SalesforceToolingClient {
   }
 
   async getDebugLogBody(logId: string): Promise<string> {
-    const response = await this.httpClient.get(
-      `sobjects/ApexLog/${logId}/Body`
-    );
-    return response.data;
+    return await this.auth.toolingRequest(`sobjects/ApexLog/${logId}/Body`);
   }
 
   // Test execution methods
@@ -280,11 +231,11 @@ export class SalesforceToolingClient {
       maxFailedTests: 1,
     };
 
-    const response = await this.httpClient.post(
-      'runTestsAsynchronous/',
-      testBody
-    );
-    return response.data;
+    return await this.auth.toolingRequest('runTestsAsynchronous/', {
+      method: 'POST',
+      body: JSON.stringify(testBody),
+      headers: { 'Content-Type': 'application/json' }
+    });
   }
 
   async getTestResults(asyncApexJobId: string): Promise<any> {
@@ -295,24 +246,10 @@ export class SalesforceToolingClient {
 
   // Organization info (uses regular SOQL API, not Tooling API)
   async getOrgInfo(): Promise<any> {
-    const token = await this.auth.getAccessToken();
-    const instanceUrl = this.auth.getInstanceUrl();
-    
-    const response = await axios.get(
-      `${instanceUrl}/services/data/v59.0/query`,
-      {
-        params: {
-          q: 'SELECT Id, Name, OrganizationType, InstanceName, IsSandbox FROM Organization LIMIT 1'
-        },
-        headers: {
-          'Authorization': `Bearer ${token}`,
-          'Content-Type': 'application/json',
-          'Accept': 'application/json'
-        }
-      }
-    );
-    
-    return response.data.records[0];
+    const soql = 'SELECT Id, Name, OrganizationType, InstanceName, IsSandbox FROM Organization LIMIT 1';
+    const url = `query?${new URLSearchParams({ q: soql }).toString()}`;
+    const response = await this.auth.restRequest(url);
+    return response.records[0];
   }
 
   // AsyncApexJob methods

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,7 +73,7 @@ class SalesforceMCPServer {
       ...createDeploymentTools(this.toolingClient),
       ...createSecurityTools(this.toolingClient),
       ...createPerformanceTools(this.toolingClient),
-      ...createOrgManagementTools(this.toolingClient),
+      ...createOrgManagementTools(this.restClient),
       ...createRestApiTools(this.restClient),
     ];
   }

--- a/src/tools/org-management-tools.ts
+++ b/src/tools/org-management-tools.ts
@@ -7,7 +7,7 @@ export function createOrgManagementTools(client: SalesforceToolingClient) {
       name: 'get_org_info',
       description: 'Get organization information',
       inputSchema: { type: 'object', properties: {} },
-      handler: async (args: any) => {
+      handler: async () => {
         try {
           // OrganizationオブジェクトはSOQL APIを使用する必要があるため、直接REST APIを呼び出し
           const orgInfo = await client.getOrgInfo();

--- a/src/tools/org-management-tools.ts
+++ b/src/tools/org-management-tools.ts
@@ -1,7 +1,6 @@
-import { z } from 'zod';
-import { SalesforceToolingClient } from '../client/tooling-client.js';
+import { SalesforceRestClient } from '../client/rest-client.js';
 
-export function createOrgManagementTools(client: SalesforceToolingClient) {
+export function createOrgManagementTools(client: SalesforceRestClient) {
   return [
     {
       name: 'get_org_info',
@@ -9,8 +8,10 @@ export function createOrgManagementTools(client: SalesforceToolingClient) {
       inputSchema: { type: 'object', properties: {} },
       handler: async () => {
         try {
-          // OrganizationオブジェクトはSOQL APIを使用する必要があるため、直接REST APIを呼び出し
-          const orgInfo = await client.getOrgInfo();
+          // Use REST API to query Organization object
+          const soql = 'SELECT Id, Name, OrganizationType, InstanceName, IsSandbox FROM Organization LIMIT 1';
+          const result = await client.query(soql);
+          const orgInfo = result.records[0];
           return {
             content: [{
               type: 'text',
@@ -19,29 +20,6 @@ export function createOrgManagementTools(client: SalesforceToolingClient) {
           };
         } catch (error) {
           return { content: [{ type: 'text', text: `Error getting org info: ${error instanceof Error ? error.message : 'Unknown error'}` }], isError: true };
-        }
-      }
-    },
-    {
-      name: 'list_sobjects',
-      description: 'List available SObjects',
-      inputSchema: { type: 'object', properties: { nameFilter: { type: 'string' }, limit: { type: 'number', default: 50, maximum: 100 } } },
-      handler: async (args: any) => {
-        const schema = z.object({ nameFilter: z.string().optional(), limit: z.number().max(100).default(50) });
-        try {
-          const parsedArgs = schema.parse(args);
-          let soql = 'SELECT QualifiedApiName, Label, IsCustom FROM EntityDefinition WHERE IsQueryable = true';
-          if (parsedArgs.nameFilter) soql += ` AND QualifiedApiName LIKE '%${parsedArgs.nameFilter}%'`;
-          soql += ` ORDER BY QualifiedApiName LIMIT ${parsedArgs.limit}`;
-          const result = await client.query(soql);
-          return {
-            content: [{
-              type: 'text',
-              text: `Available SObjects (${result.records.length}):\n\n${result.records.map((obj: any) => `• ${obj.QualifiedApiName} - ${obj.Label}${obj.IsCustom ? ' (Custom)' : ''}`).join('\n')}`
-            }]
-          };
-        } catch (error) {
-          return { content: [{ type: 'text', text: `Error listing SObjects: ${error instanceof Error ? error.message : 'Unknown error'}` }], isError: true };
         }
       }
     }


### PR DESCRIPTION
This pull request refactors the Salesforce authentication and client logic to remove direct dependencies on `axios` and instead route all REST and Tooling API calls through the `SalesforceAuth` class. This improves testability and modularity by abstracting HTTP request logic behind the authentication layer. The test suites for both REST and Tooling clients are updated to mock the new request methods, simplifying setup and expectations.

**Refactoring authentication and request logic:**

* The `SalesforceAuth` class now exposes `restRequest` and `toolingRequest` methods for making API calls, replacing the previous direct access token and instance URL methods. Connections are no longer cached and are created per request for improved reliability. (`src/auth/salesforce-auth.ts`) [[1]](diffhunk://#diff-9ec428768e1ae55ee006b1d6d6cea7c8f95471601de1be06a19e0ae8329d5b26L17-L45) [[2]](diffhunk://#diff-9ec428768e1ae55ee006b1d6d6cea7c8f95471601de1be06a19e0ae8329d5b26L68-R57)
* Removed internal caching of the Salesforce connection in `SalesforceAuth`, making connection handling more stateless. (`src/auth/salesforce-auth.ts`)

**Test suite modernization:**

* The REST client test suite (`rest-client.test.ts`) is refactored to mock `restRequest` on the auth object instead of mocking `axios`, and all expectations now assert calls to `restRequest` rather than HTTP client calls. (`src/client/__tests__/rest-client.test.ts`) [[1]](diffhunk://#diff-6bee74f5f1371afe73d2b40abd9296d08d6148aec95ec438827d63a8787653f5L1-L14) [[2]](diffhunk://#diff-6bee74f5f1371afe73d2b40abd9296d08d6148aec95ec438827d63a8787653f5L29-L47) [[3]](diffhunk://#diff-6bee74f5f1371afe73d2b40abd9296d08d6148aec95ec438827d63a8787653f5L56-R233)
* The Tooling client test suite (`tooling-client.test.ts`) is similarly updated to mock `toolingRequest` and `restRequest` methods, removing all direct HTTP client mocking and setup. (`src/client/__tests__/tooling-client.test.ts`) [[1]](diffhunk://#diff-a3ee0ee79a84330c5e32d564895e2641185638676bf5b66a8b6d4fa9d9468b42L1-L14) [[2]](diffhunk://#diff-a3ee0ee79a84330c5e32d564895e2641185638676bf5b66a8b6d4fa9d9468b42L29-L46)